### PR TITLE
Applying 'form-control to bsdate in bs3

### DIFF
--- a/src/js/themes.js
+++ b/src/js/themes.js
@@ -66,7 +66,6 @@ angular.module('xeditable').factory('editableThemes', function() {
           case 'editableDate':
           case 'editableDatetime':
           case 'editableBsdate':
-          case 'editableBstime':
           case 'editableTime':
           case 'editableMonth':
           case 'editableWeek':

--- a/src/js/themes.js
+++ b/src/js/themes.js
@@ -65,6 +65,8 @@ angular.module('xeditable').factory('editableThemes', function() {
           case 'editableSearch':
           case 'editableDate':
           case 'editableDatetime':
+          case 'editableBsdate':
+          case 'editableBstime':
           case 'editableTime':
           case 'editableMonth':
           case 'editableWeek':


### PR DESCRIPTION
Added cases for editableBsdate and editableBstime in the directive-name switch statement in the BS3 theme to add the 'form-control' class to the input element generated.

[before](http://i.imgur.com/agFFScG.png)
(font looks odd because it's in an h3)

[after](http://i.imgur.com/EUHFzqL)