### PR TITLE
Fixed angular.copy issue

### DIFF
--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -416,7 +416,8 @@ angular.module('xeditable').factory('editableController',
     };
 
     self.save = function() {
-      valueGetter.assign($scope.$parent, angular.copy(self.scope.$data));
+      valueGetter.assign($scope.$parent,
+          self.useCopy ? angular.copy(self.scope.$data) : self.scope.$data);
 
       // no need to call handleEmpty here as we are watching change of model value
       // self.handleEmpty();


### PR DESCRIPTION
`angular.copy` must not be used (as you also wrote) when dealing with (heavy) objects. there is another place where using `angular.copy`, but validation is performed there.