### PR TITLE
Fix for Issue #162 

### DIFF
--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -333,8 +333,8 @@ angular.module('xeditable').factory('editableController',
         self.autosubmit();
       }
 
-      // click - mark element as clicked to exclude in document click handler
-      self.editorEl.bind('click', function(e) {
+      // mouseup - mark element as clicked to exclude in document mouseup handler
+      self.editorEl.bind('mouseup', function(e) {
         // ignore right/middle button click
         if (e.which !== 1) {
           return;

--- a/src/js/editable-form/controller.js
+++ b/src/js/editable-form/controller.js
@@ -8,8 +8,8 @@ angular.module('xeditable').factory('editableFormController',
   // array of opened editable forms
   var shown = [];
 
-  // bind click to body: cancel|submit|ignore forms
-  $document.bind('click', function(e) {
+  // bind mouseup to body: cancel|submit|ignore forms
+  $document.bind('mouseup', function(e) {
     // ignore right/middle button click
     if (e.which !== 1) {
       return;

--- a/src/js/editable-form/directive.js
+++ b/src/js/editable-form/directive.js
@@ -143,8 +143,8 @@ angular.module('xeditable').directive('editableForm',
             }
 
 
-            // click - mark form as clicked to exclude in document click handler
-            elem.bind('click', function(e) {
+            // mouseup - mark form as clicked to exclude in document click handler
+            elem.bind('mouseup', function(e) {
               // ignore right/middle button click
               if (e.which !== 1) {
                 return;


### PR DESCRIPTION
I have found the cause and a fix for this issue.

Proposed fix for blur cancel/submit not working in IE8
https://github.com/vitalets/angular-xeditable/issues/162

---

The `onblur` is implemented by listening a mouse click on the document. 

In `editable-form/controller.js`, 

```
// bind click to body: cancel|submit|ignore forms
$document.bind('click', function (e) {

    // ignore right/middle button click
    if (e.which !== 1) {
        return;
    }
```

The issue is caused by `event.which` (http://api.jquery.com/event.which/) reporting `0` for **all mouse clicks in IE8**, forcing this function to return early. This has been reported as a jQuery bug (http://bugs.jquery.com/ticket/13209), however it was subsequently closed as apparently the button data isn't available in IE8.

**Solution**

Change `$document.bind('click', function (e)` to `$document.bind('mouseup', function (e)` as the mouseup event has the correct data for the `.which` property. 

I have tested this in IE8, IE11, Firefox 17, Chrome.
