### PR TITLE
Fix for issue #130 - Updating form view value.

### DIFF
--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -172,6 +172,7 @@ angular.module('xeditable').factory('editableController',
       // Initially this method called with newVal = undefined, oldVal = undefined
       // so no need initially call handleEmpty() explicitly
       $scope.$parent.$watch($attrs[self.directiveName], function(newVal, oldVal) {
+        self.setLocalValue();
         self.handleEmpty();
       });
     };


### PR DESCRIPTION
Currently if the main model is updated the forms view value doesn't get updated with the new value, the inputs scope and $data reflect the update but not the view as shown in this [issue](https://github.com/vitalets/angular-xeditable/issues/130)