### PR TITLE
Make e-form more flexible, when there isn't parent form element

### DIFF
--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -110,7 +110,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
 
           // if `e-form` provided, publish local $form in scope
           if(attrs.eForm) {
-            scope.$parent[attrs.eForm] = scope.$form;
+            $parse(attrs.eForm).assign(scope, scope.$form);
           }
 
           // bind click - if no external form defined


### PR DESCRIPTION
This little changes allow to bind form controller not only to $parent scope.

For example this will work as expected, and ng-if created scope not absorb "item.amountField" as its own property.

```html
<a editable-number="item.amount" 
	e-required 
	e-min="0"
	e-form="item.amountField"
	ng-if="item.isEnabled">
		{{ (item.amount }}
</a>
<!-- ... -->
<button class="btn btn-default" ng-click="item.amountField.$show()" ng-if="item.isEnabled"> 
Activate
</button>
```