### PR TITLE
Fix checkbox form alignment

### DIFF
--- a/src/js/directives/checkbox.js
+++ b/src/js/directives/checkbox.js
@@ -8,7 +8,7 @@ angular.module('xeditable').directive('editableCheckbox', ['editableDirectiveFac
         this.parent.render.call(this);
         if(this.attrs.eTitle) {
           this.inputEl.wrap('<label></label>');
-          this.inputEl.after(angular.element('<span></span>').text(this.attrs.eTitle));
+          this.inputEl.parent().append(this.attrs.eTitle);
         }
       },
       autosubmit: function() {

--- a/src/js/themes.js
+++ b/src/js/themes.js
@@ -79,6 +79,8 @@ angular.module('xeditable').factory('editableThemes', function() {
               this.inputEl.addClass(this.theme.inputClass);
             }
           break;
+          case 'editableCheckbox':
+              this.editorEl.addClass('checkbox');
         }
 
         //apply buttonsClass (bs3 specific!)


### PR DESCRIPTION
This is a PR for issue https://github.com/vitalets/angular-xeditable/issues/213

I would have removed the span in the bs3 specific theme but since the directive elements are created after the ```postrender``` is called... I can't :-(