### PR TITLE
Fix IE8 accidental onblur.

### DIFF
--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -336,7 +336,7 @@ angular.module('xeditable').factory('editableController',
       // click - mark element as clicked to exclude in document click handler
       self.editorEl.bind('click', function(e) {
         // ignore right/middle button click
-        if (e.which !== 1) {
+        if (e.which && e.which !== 1) {
           return;
         }
 

--- a/src/js/editable-form/controller.js
+++ b/src/js/editable-form/controller.js
@@ -11,7 +11,7 @@ angular.module('xeditable').factory('editableFormController',
   // bind click to body: cancel|submit|ignore forms
   $document.bind('click', function(e) {
     // ignore right/middle button click
-    if (e.which !== 1) {
+    if (e.which && e.which !== 1) {
       return;
     }
 

--- a/src/js/editable-form/directive.js
+++ b/src/js/editable-form/directive.js
@@ -146,7 +146,7 @@ angular.module('xeditable').directive('editableForm',
             // click - mark form as clicked to exclude in document click handler
             elem.bind('click', function(e) {
               // ignore right/middle button click
-              if (e.which !== 1) {
+              if (e.which && e.which !== 1) {
                 return;
               }
 


### PR DESCRIPTION
Issue on IE8 (maybe IE10 emulation only): click inside editable text
input triggers onblur (field is, consequently, no more editable).