### PR TITLE
fix #225 'Feature: choose event to activate edit mode'

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
                 <ul class="nav">
                   <li><a href="#ref-element">Editable element</a></li>
                   <li><a href="#ref-form">Editable form</a></li>
+                  <li><a href="#ref-options">Editable options</a></li>
                 </ul>
               </li>
             </ul>
@@ -2515,6 +2516,107 @@ to model.<br>If at least one children callback returns <code>non-string</code> -
                           </td>
                           <td><p>Shows form with editable controls.</p>
 </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    
+                    
+          <section id="ref-options"></section>
+          <h2>Reference: Editable options</h2>
+          <h3>Change Options</h3>
+          <p>Options can be edited the following way:</p>
+          <pre class="prettyprint">
+app.run(function(editableOptions) {
+  editableOptions.&lt;name&gt; = &lt;value&gt;;
+});
+          </pre>
+          <h3>Available Options</h3>
+          <table width="100%" class="table-bordered table-condensed">
+                      <thead>
+                        <tr>
+                          <th width="15%">Name</th>
+                          <th>Type</th>
+                          <th>Possible Values</th>
+                          <th>Default</th>
+                          <th>Description</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td><code>theme</code></td>
+                          <td>string</td>
+                          <td>
+                            <p>
+                                <code>'bs3'</code><br>
+                                <code>'bs2'</code><br>
+                                <code>'default'</code>
+                            </p>
+                          </td>
+                          <td><code>'default'</code></td>
+                          <td><p>Set the Theme for all editable-elements.</p></td>
+                        </tr>
+                        <tr>
+                          <td><code>buttons</code></td>
+                          <td>string</td>
+                          <td>
+                            <p>
+                                <code>'right'</code><br>
+                                <code>'no'</code>
+                            </p>
+                          </td>
+                          <td><code>'right'</code></td>
+                          <td><p><i>See <a href="#ref-element">Reference: editable element</a></i></p></td>
+                        </tr>
+                        <tr>
+                          <td><code>blurElem</code></td>
+                          <td>string</td>
+                          <td>
+                            <p>
+                                <code>'cancel'</code><br>
+                                <code>'submit'</code><br>
+                                <code>'ignore'</code>
+                            </p>
+                          </td>
+                          <td><code>'cancel'</code></td>
+                          <td><p><i>See <a href="#ref-element">Reference: editable element</a></i></p></td>
+                        </tr>
+                        <tr>
+                          <td><code>blurForm</code></td>
+                          <td>string</td>
+                          <td>
+                            <p>
+                                <code>'cancel'</code><br>
+                                <code>'submit'</code><br>
+                                <code>'ignore'</code>
+                            </p>
+                          </td>
+                          <td><code>'ignore'</code></td>
+                          <td><p><i>See <a href="#ref-form">Reference: editable form</a></i></p></td>
+                        </tr>
+                        <tr>
+                          <td><code>activate</code></td>
+                          <td>string</td>
+                          <td>
+                            <p>
+                                <code>'focus'</code><br>
+                                <code>'select'</code><br>
+                                <code>'none'</code>
+                            </p>
+                          </td>
+                          <td><code>'focus'</code></td>
+                          <td><p>How input elements get activated.</p></td>
+                        </tr>
+                        <tr>
+                          <td><code>activationEvent</code></td>
+                          <td>string</td>
+                          <td>
+                            <p>
+                                <i>any Event</i><br>
+                                p.e. <code>click</code>, <code>dblclick</code>, <code>mouseover</code>, ...
+                            </p>
+                          </td>
+                          <td><code>'click'</code></td>
+                          <td><p>Event, on which the edit mode gets activated.</p></td>
                         </tr>
                       </tbody>
                     </table>

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -11,8 +11,8 @@ Inside it does several things:
 Depends on: editableController, editableFormFactory
 */
 angular.module('xeditable').factory('editableDirectiveFactory',
-['$parse', '$compile', 'editableThemes', '$rootScope', '$document', 'editableController', 'editableFormController',
-function($parse, $compile, editableThemes, $rootScope, $document, editableController, editableFormController) {
+['$parse', '$compile', 'editableThemes', '$rootScope', '$document', 'editableController', 'editableFormController', 'editableOptions'
+function($parse, $compile, editableThemes, $rootScope, $document, editableController, editableFormController, editableOptions) {
 
   //directive object
   return function(overwrites) {
@@ -116,7 +116,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
           // bind click - if no external form defined
           if(!attrs.eForm) {
             elem.addClass('editable-click');
-            elem.bind('click', function(e) {
+            elem.bind(editableOptions.activationEvent, function(e) {
               e.preventDefault();
               e.editable = eCtrl;
               scope.$apply(function(){

--- a/src/js/module.js
+++ b/src/js/module.js
@@ -50,5 +50,14 @@ angular.module('xeditable', [])
    * @memberOf editable-options
    */
   activate: 'focus'
+  
+  /**
+   * Event, on which the edit mode gets activated. 
+   * Can be any event.
+   *
+   * @var {string} activationEvent
+   * @memberOf editable-options
+   */
+  activationEvent: 'click'
 
 });


### PR DESCRIPTION
activation event can now be choosen via <code>editableOptions.activationEvent = '...'</code> and defaults to <code>'click'</code>!
documentation included.