### PR TITLE
Revert "Make e-form more flexible, when there isn't parent form element"

### DIFF
--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -119,7 +119,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
 
           // if `e-form` provided, publish local $form in scope
           if(attrs.eForm) {
-            $parse(attrs.eForm).assign(scope, scope.$form);
+            scope.$parent[attrs.eForm] = scope.$form;
           }
 
           // bind click - if no external form defined


### PR DESCRIPTION
Reverts vitalets/angular-xeditable#212

This is a breaking change that creates the issue described in #263