### PR TITLE
Fixed text-disable so it "Watches" the actual value of the edit-disabled attribute instead of the initial value

### DIFF
--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -83,7 +83,7 @@ function($parse, $compile, editableThemes, editableOptions, $rootScope, $documen
           scope.$eval(attrs.editDisabled) :
           editableOptions.isDisabled;
           return disabled;
-        }
+        };
 
         // init editable ctrl
         eCtrl.init(!hasForm);

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -77,14 +77,12 @@ function($parse, $compile, editableThemes, editableOptions, $rootScope, $documen
         // merge overwrites to base editable controller
         angular.extend(eCtrl, overwrites);
 
-
-	// x-editable can be disabled using editableOption or edit-disabled attribute
-        var disabled = angular.isDefined(attrs.editDisabled) ?
+        // x-editable can be disabled using editableOption or edit-disabled attribute
+        var is_disabled = function() {
+          disabled = angular.isDefined(attrs.editDisabled) ?
           scope.$eval(attrs.editDisabled) :
           editableOptions.isDisabled;
-
-        if (disabled) {
-          return;
+          return disabled;
         }
 
         // init editable ctrl
@@ -129,9 +127,11 @@ function($parse, $compile, editableThemes, editableOptions, $rootScope, $documen
             elem.bind('click', function(e) {
               e.preventDefault();
               e.editable = eCtrl;
-              scope.$apply(function(){
-                scope.$form.$show();
-              });
+              if(!is_disabled()) {
+                scope.$apply(function(){
+                  scope.$form.$show();
+                });
+              }
             });
           }
         }


### PR DESCRIPTION
Now it checks the variable at the moment of opening the input (clicking on the editable text) instead of checking the variable when the directive instance is created.