### PR TITLE
Add blur event to single element to hide the input control

### DIFF
--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -338,6 +338,24 @@ angular.module('xeditable').factory('editableController',
           }
       });
 
+      // bind blur for when really losing focus
+      // on single inputs
+      self.inputEl.bind('blur', function(e) {
+          if(!self.single) {
+            return;
+          }
+          if (e.keyCode === 9) {
+            e.preventDefault();
+          }
+          self.scope.$apply(function() {
+            if (self.attrs.blur === 'submit') {
+              self.scope.$form.$submit();
+            } else {
+              self.scope.$form.$cancel();
+            }
+          });
+      });
+
       // autosubmit when `no buttons`
       if (self.single && self.buttons === 'no') {
         self.autosubmit();


### PR DESCRIPTION
This will allow the user to close the input field (on single) when the input really loses focus (clicking outside or pressing tab key), right now it is not doing anything on tab key and for single element the UX would be to close the edit input and perform the blur action (submit or cancel).

NOTE: hope this can be reviewed, merged and deploy ASAP as this is a functionality I really need and I know it is something we may all too. 
