### PR TITLE
Fix for #6 < unable to use single xeditable form elements (without whole form editing) + use angular's form validation

### DIFF
--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -34,19 +34,14 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         var hasForm = false;
      
         var isSingle = false;
-        if (attrs.eSingle !== undefined){
+        if(attrs.eSingle !== undefined) {
           isSingle = true;
         }
+
         // element wrapped by form
         if(ctrl[1]) {
           eFormCtrl = ctrl[1];
-          if (isSingle){
-            hasForm = false;
-          }
-          else
-          {
-            hasForm = true;  
-          }
+          hasForm = !isSingle;
         } else if(attrs.eForm) { // element not wrapped by <form>, but we hane `e-form` attr
           var getter = $parse(attrs.eForm)(scope);
           if(getter) { // form exists in scope (above), e.g. editable column

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -33,10 +33,20 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         // By default consider single element without any linked form.ß
         var hasForm = false;
      
+        var isSingle = false;
+        if (attrs.eSingle !== undefined){
+          isSingle = true;
+        }
         // element wrapped by form
         if(ctrl[1]) {
           eFormCtrl = ctrl[1];
-          hasForm = true;
+          if (isSingle){
+            hasForm = false;
+          }
+          else
+          {
+            hasForm = true;  
+          }
         } else if(attrs.eForm) { // element not wrapped by <form>, but we hane `e-form` attr
           var getter = $parse(attrs.eForm)(scope);
           if(getter) { // form exists in scope (above), e.g. editable column

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -33,10 +33,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         // By default consider single element without any linked form.ß
         var hasForm = false;
      
-        var isSingle = false;
-        if(attrs.eSingle !== undefined) {
-          isSingle = true;
-        }
+        var isSingle = attrs.eSingle !== undefined;
 
         // element wrapped by form
         if(ctrl[1]) {


### PR DESCRIPTION
This fix addresses http://github.com/vitalets/angular-xeditable/issues/6)
To use, simply include e-single on any element you wish to 'ignore' the hasForm variable.

Example:
`<a href="#" editable-text="person.FirstName" e-required e-placeholder="First Name" e-single>{{ person.FirstName || \'First Name\' }}</a>`

Passes JShint