### PR TITLE
Fix for #6 unable to use single xeditable form elements (without whole form editing) + use angular's form validation #314

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,18 +681,18 @@ Other parameters can be defined via <code>e-*</code> syntax, e.g. <code>e-datepi
 </p>
                       <!--script(src=dir+'/controller.js')-->
                       <script>app.controller('BsdateCtrl', function($scope) {
-	$scope.user = {
-		dob: new Date(1984, 4, 15)
-	};
+  $scope.user = {
+    dob: new Date(1984, 4, 15)
+  };
 
-	$scope.opened = {};
+  $scope.opened = {};
 
-	$scope.open = function($event, elementOpened) {
-		$event.preventDefault();
-		$event.stopPropagation();
+  $scope.open = function($event, elementOpened) {
+    $event.preventDefault();
+    $event.stopPropagation();
 
-		$scope.opened[elementOpened] = !$scope.opened[elementOpened];
-	};
+    $scope.opened[elementOpened] = !$scope.opened[elementOpened];
+  };
 $scope.$watch("user", function(v) { $scope.$parent.debug["bsdate"]=v; }); });</script>
                       <h3>html</h3>
                       <pre class="prettyprint ng-non-bindable">&lt;div ng-controller=&quot;BsdateCtrl&quot;&gt;
@@ -702,18 +702,18 @@ $scope.$watch("user", function(v) { $scope.$parent.debug["bsdate"]=v; }); });</s
 &lt;/div&gt;</pre>
                       <h3>controller.js</h3>
                       <pre class="prettyprint">app.controller('BsdateCtrl', function($scope) {
-	$scope.user = {
-		dob: new Date(1984, 4, 15)
-	};
+  $scope.user = {
+    dob: new Date(1984, 4, 15)
+  };
 
-	$scope.opened = {};
+  $scope.opened = {};
 
-	$scope.open = function($event, elementOpened) {
-		$event.preventDefault();
-		$event.stopPropagation();
+  $scope.open = function($event, elementOpened) {
+    $event.preventDefault();
+    $event.stopPropagation();
 
-		$scope.opened[elementOpened] = !$scope.opened[elementOpened];
-	};
+    $scope.opened[elementOpened] = !$scope.opened[elementOpened];
+  };
 });</pre>
                     </section>
                     <section id="bstime">
@@ -1246,7 +1246,7 @@ $scope.$watch("user", function(v) { $scope.$parent.debug["onaftersave"]=v; }); }
 });</pre>
                     </section>
                     <section id="editable-form">
-                      <h1>Editable form</h1>
+                      <h1>Editable form (with single item example)</h1>
                       <!-- watch change of user to update rootScope for debugging-->
                       <h3>demo</h3><a href="http://jsfiddle.net/NfPcH/81/" target="_blank" class="btn btn-info fiddle pull-right">jsFiddle</a>
                       <div class="well line-example"><div ng-controller="EditableFormCtrl">
@@ -1272,6 +1272,13 @@ $scope.$watch("user", function(v) { $scope.$parent.debug["onaftersave"]=v; }); }
         {{ showGroup() }}
       </span>
     </div>
+
+    <div>
+      <div>Below is an example of how to edit a single item inside of a form</div>
+      <!-- editable single Item user (text with validation) -->
+      <span class="title">User name: </span>
+      <a href="#" editable-text="user.name" e-name="name" e-single onbeforesave="checkName($data)" e-required>{{ user.name || 'empty' }}</a>
+    </div> 
 
     <div class="buttons">
       <!-- button to show form -->
@@ -1332,6 +1339,10 @@ $scope.$watch("user", function(v) { $scope.$parent.debug["onaftersave"]=v; }); }
 <li><code>not string</code>: form will be closed</li>
 </ul>
 <p>Commonly you should define <code>onbeforesave</code> for child elements to perform validation and <code>onaftersave</code> for whole form to send data on server.</p>
+<p>Additionally, a user will need to have a single editable element when the entire application is wrapped in a global form tag.  To enable this single item to be edited add <code>e-single</code> to the directive.
+<ul>
+<li> <code>&lt;a href=&quot;#&quot; editable-text=&quot;user.name&quot; e-name=&quot;name&quot; e-single e-required&gt;AngularElementHere&lt;/a&gt;</code></li>
+</ul>
 <p>Please have a look at examples.</p>
 </p>
                       <!--script(src=dir+'/controller.js')-->
@@ -1410,6 +1421,13 @@ $scope.$watch("user", function(v) { $scope.$parent.debug["onaftersave"]=v; }); }
         {{ showGroup() }}
       &lt;/span&gt;
     &lt;/div&gt;
+
+    &lt;div&gt;
+      &lt;div&gt;Below is an example of how to edit a single item inside of a form&lt;/div&gt;
+      &lt;!-- editable single Item user (text with validation) --&gt;
+      &lt;span class=&quot;title&quot;&gt;User name: &lt;/span&gt;
+      &lt;a href=&quot;#&quot; editable-text=&quot;user.name&quot; e-name=&quot;name&quot; e-single onbeforesave=&quot;checkName($data)&quot; e-required&gt;{{ user.name || &#39;empty&#39; }}&lt;/a&gt;
+    &lt;/div&gt; 
 
     &lt;div class=&quot;buttons&quot;&gt;
       &lt;!-- button to show form --&gt;

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -33,12 +33,10 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         // By default consider single element without any linked form.ß
         var hasForm = false;
      
-        var isSingle = attrs.eSingle !== undefined;
-
         // element wrapped by form
         if(ctrl[1]) {
           eFormCtrl = ctrl[1];
-          hasForm = !isSingle;
+          hasForm = attrs.eSingle === undefined;
         } else if(attrs.eForm) { // element not wrapped by <form>, but we hane `e-form` attr
           var getter = $parse(attrs.eForm)(scope);
           if(getter) { // form exists in scope (above), e.g. editable column

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -34,19 +34,14 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         var hasForm = false;
      
         var isSingle = false;
-        if (attrs.eSingle !== undefined){
+        if(attrs.eSingle !== undefined) {
           isSingle = true;
         }
+
         // element wrapped by form
         if(ctrl[1]) {
           eFormCtrl = ctrl[1];
-          if (isSingle){
-            hasForm = false;
-          }
-          else
-          {
-            hasForm = true;  
-          }
+          hasForm = !isSingle;
         } else if(attrs.eForm) { // element not wrapped by <form>, but we hane `e-form` attr
           var getter = $parse(attrs.eForm)(scope);
           if(getter) { // form exists in scope (above), e.g. editable column

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -33,10 +33,20 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         // By default consider single element without any linked form.ß
         var hasForm = false;
      
+        var isSingle = false;
+        if (attrs.eSingle !== undefined){
+          isSingle = true;
+        }
         // element wrapped by form
         if(ctrl[1]) {
           eFormCtrl = ctrl[1];
-          hasForm = true;
+          if (isSingle){
+            hasForm = false;
+          }
+          else
+          {
+            hasForm = true;  
+          }
         } else if(attrs.eForm) { // element not wrapped by <form>, but we hane `e-form` attr
           var getter = $parse(attrs.eForm)(scope);
           if(getter) { // form exists in scope (above), e.g. editable column

--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -33,10 +33,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         // By default consider single element without any linked form.ß
         var hasForm = false;
      
-        var isSingle = false;
-        if(attrs.eSingle !== undefined) {
-          isSingle = true;
-        }
+        var isSingle = attrs.eSingle !== undefined;
 
         // element wrapped by form
         if(ctrl[1]) {


### PR DESCRIPTION
This fix addresses http://github.com/vitalets/angular-xeditable/issues/6)
To use, simply include e-single on any element you wish to 'ignore' the hasForm variable.

Example:
`<a href="#" editable-text="person.FirstName" e-required e-placeholder="First Name" e-single>{{ person.FirstName || \'First Name\' }}</a>`

Passes JShint, also i wanted to create a branch on my fork for this fix, so that explains 2 pull requests, one closed.