### PR TITLE
Make new editables added to a form match the waiting state of the form

### DIFF
--- a/src/js/editable-form/controller.js
+++ b/src/js/editable-form/controller.js
@@ -95,6 +95,7 @@ angular.module('xeditable').factory('editableFormController',
       if (this.$visible) {
         editable.catchError(editable.show());
       }
+      editable.catchError(editable.setWaiting(this.$waiting));
     },
 
     $removeEditable: function(editable) {


### PR DESCRIPTION
When adding a new item to an editable form, the waiting state of the new item needs to match the waiting state of the rest of the form.