### PR TITLE
Alwaysshown attribute to prevent $hide with save and cancel

### DIFF
--- a/index.html
+++ b/index.html
@@ -2509,6 +2509,12 @@ to model.<br>If at least one children callback returns <code>non-string</code> -
                           <td><p>Whether form initially rendered in shown state.</p>
 </td>
                         </tr>
+                        <tr>
+                          <td><code>alwaysshown</code></td>
+                          <td>bool</td>
+                          <td><p>Whether form always rendered in shown state.</p>
+</td>
+                        </tr>
                       </tbody>
                     </table>
           <h3>Properties</h3><p>Properties are available when you set <code>name</code> attribute of form: </p>

--- a/src/js/editable-form/controller.js
+++ b/src/js/editable-form/controller.js
@@ -193,7 +193,7 @@ angular.module('xeditable').factory('editableFormController',
      * @memberOf editable-form
      */
     $hide: function() {
-      if (!this.$visible) {
+      if (!this.$visible || this.$alwaysShown) {
         return;
       }      
       this.$visible = false;

--- a/src/js/editable-form/directive.js
+++ b/src/js/editable-form/directive.js
@@ -91,9 +91,17 @@ angular.module('xeditable').directive('editableForm',
              */
             if(attrs.shown && $parse(attrs.shown)(scope)) {
               eForm.$show();
-              if (attrs.alwaysshown && $parse(attrs.alwaysshown)(scope)) {
-                eForm.$alwaysShown = true;
-              }
+            }
+
+            /**
+             * Whether form always rendered in shown state.
+             *
+             * @var {bool|attribute} alwaysshown
+             * @memberOf editable-form
+             */
+            if (attrs.alwaysshown && $parse(attrs.alwaysshown)(scope)) {
+              eForm.$show();
+              eForm.$alwaysShown = true;
             }
 
             /**

--- a/src/js/editable-form/directive.js
+++ b/src/js/editable-form/directive.js
@@ -91,6 +91,9 @@ angular.module('xeditable').directive('editableForm',
              */
             if(attrs.shown && $parse(attrs.shown)(scope)) {
               eForm.$show();
+              if (attrs.alwaysshown && $parse(attrs.alwaysshown)(scope)) {
+                eForm.$alwaysShown = true;
+              }
             }
 
             /**


### PR DESCRIPTION
Added attribute alwaysshown to xeditable-form. Ensures that form is initially shown (as with shown attribute) and prevents $hide execution in all situations.