### PR TITLE
Make 'e-form' publish local $form even if specify object property

### DIFF
--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -119,7 +119,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
 
           // if `e-form` provided, publish local $form in scope
           if(attrs.eForm) {
-            scope.$parent[attrs.eForm] = scope.$form;
+            ($parse(attrs.eForm).assign || angular.noop)(scope.$parent, scope.$form);
           }
 
           // bind click - if no external form defined


### PR DESCRIPTION
Publishing local `$form` to some variable is everything ok, but doing to some object property does no work

```js
<!-- $form will be published -->
<span editable-text="user.name" e-form="form"> 

<!-- $form will not be published-->
<span editable-text="user.name" e-form="ctrl.form"> 
```

plunker: http://plnkr.co/edit/jMTP57413JZPFmsVJlZu?p=preview