### PR TITLE
Allow passing min/maxYear to combodate

### DIFF
--- a/docs/demos/combodate/desc.md
+++ b/docs/demos/combodate/desc.md
@@ -1,3 +1,4 @@
 You should include additional `moment.js`:
 
 And set `editable-combodate` attribute in editable element.
+Custom options supported by [Combodate](https://vitalets.github.io/combodate/) can be provided via `e-*` syntax, e.g. `e-min-year="2015"`.

--- a/src/js/directives/combodate.js
+++ b/src/js/directives/combodate.js
@@ -6,9 +6,20 @@ angular.module('xeditable').directive('editableCombodate', ['editableDirectiveFa
       inputTpl: '<input type="text">',
       render: function() {
         this.parent.render.call(this);
-        var combodate = editableCombodate.getInstance(this.inputEl, {value: new Date(this.scope.$data)});
 
+        var options = {
+          value: new Date(this.scope.$data)
+        };
         var self = this;
+        angular.forEach(["format", "template", "minYear", "maxYear", "yearDescending", "minuteStep", "secondStep", "firstItem", "errorClass", "customClass", "roundTime", "smartDays"], function(name) {
+
+          var attrName = "e" + name.charAt(0).toUpperCase() + name.slice(1);
+          if (attrName in self.attrs) {
+            options[name] = self.attrs[attrName];
+          }
+        });
+
+        var combodate = editableCombodate.getInstance(this.inputEl, options);
         combodate.$widget.find('select').bind('change', function(e) {
           self.scope.$data = (new Date(combodate.getValue())).toISOString();
         });


### PR DESCRIPTION
Currently maxYear is hardcoded to 2015, making the control unusable for us. Not sure what the best option is. This pull request adds pass through of `e-min/max-year` attributes to combodate control.