### PR TITLE
Remove `isDefaultPrevented()` check

### DIFF
--- a/src/js/editable-form/controller.js
+++ b/src/js/editable-form/controller.js
@@ -41,7 +41,7 @@ angular.module('xeditable').factory('editableFormController',
   // bind click to body: cancel|submit|ignore forms
   $document.bind('click', function(e) {
     // ignore right/middle button click
-    if ((e.which && e.which !== 1) || e.isDefaultPrevented()) {
+    if (e.which && e.which !== 1) {
       return;
     }
 


### PR DESCRIPTION
Checking for isDefaultPrevented() causes the check for form blur to be avoided in many cases where the form actually is blurred and the form should be canceled if the user has set `blur="cancel"` on the editable form.

This is the only place in the code that checks isDefaultPrevented(), and it is not required to prevent blur on a right click.