### PR TITLE
Fix finding form controller when elements not yet in DOM

### DIFF
--- a/src/js/editable-element/directive.js
+++ b/src/js/editable-element/directive.js
@@ -28,11 +28,11 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         // form controller
         var eFormCtrl;
 
-        // this variable indicates is element is bound to some existing form, 
+        // this variable indicates is element is bound to some existing form,
         // or it's single element who's form will be generated automatically
         // By default consider single element without any linked form.ß
         var hasForm = false;
-     
+
         // element wrapped by form
         if(ctrl[1]) {
           eFormCtrl = ctrl[1];
@@ -42,15 +42,10 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
           if(getter) { // form exists in scope (above), e.g. editable column
             eFormCtrl = getter;
             hasForm = true;
-          } else { // form exists below or not exist at all: check document.forms
-            for(var i=0; i<$document[0].forms.length;i++){
-              if($document[0].forms[i].name === attrs.eForm) {
-                // form is below and not processed yet
-                eFormCtrl = null;
-                hasForm = true;
-                break;
-              }
-            }
+          } else if(elem.parents().last().find('form[name='+attrs.eForm+']').length) { // form exists below or not exist at all: check document.forms
+            // form is below and not processed yet
+            eFormCtrl = null;
+            hasForm = true;
           }
         }
 
@@ -85,7 +80,7 @@ function($parse, $compile, editableThemes, $rootScope, $document, editableContro
         if (disabled) {
           return;
         }
-        
+
         // init editable ctrl
         eCtrl.init(!hasForm);
 


### PR DESCRIPTION
I bumped into a problem with xeditable today when using it for editing columns in a row as explained here https://vitalets.github.io/angular-xeditable/#editable-row. 

The use case is when the editable element is outside of the form, i.e. something like this

```
      <td>
        <span editable-text="user.name" e-name="name" e-form="rowform">
          {{ user.name || 'empty' }}
        </span>
      </td>
      <td style="white-space: nowrap">
        <form editable-form name="rowform" ng-show="rowform.$visible" class="form-buttons form-inline">
          <!-- form stuff here -->
        </form>
        <div class="buttons" ng-show="!rowform.$visible">
          <button class="btn btn-primary" ng-click="rowform.$show()">edit</button>
        </div>
      </td>
```
Now this works fine when all of the HTML is in DOM when the directives compile and link, but in my case I'm using these directives in a piece of markup that gets compiled and inserted into DOM after the page has loaded. 

This has implications here https://github.com/vitalets/angular-xeditable/blob/master/src/js/editable-element/directive.js#L47 since we're looking for the form element in DOM, but the element (which is being compiled and linked in memory) isn't available in the DOM yet. 

So I figured that we could find the topmost parent to the directive's element and look for the form from there. In the "normal" case, the search would stem from the document root and thus be equal to the former implementation, but in my case the search would start from the topmost element of the HTML excerpt that will be inserted into DOM.

What do you think? 