### PR TITLE
Fix - Memory leak when ending editing by destroying the scope.

### DIFF
--- a/docs/demos/checkbox/test.js
+++ b/docs/demos/checkbox/test.js
@@ -17,7 +17,7 @@ describe('checkbox', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').check();
+    using(s).input('$parent.$data').check();
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a:visible').count()).toBe(1);

--- a/docs/demos/dev-form/test.js
+++ b/docs/demos/dev-form/test.js
@@ -58,7 +58,7 @@ describe('dev-form', function() {
     expect(element(s+'input[type="text"]:enabled:visible').count()).toBe(1);
 
     //set some value
-    using(s+'form > div:eq(0)').input('$data').enter('username2');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('username2');
 
     //click input --> no action, form shown
     element(s+'input[type="text"]').click();
@@ -93,7 +93,7 @@ describe('dev-form', function() {
     expect(element(s+'input[type="text"]:enabled:visible').count()).toBe(1);
 
     //set some value
-    using(s+'form > div:eq(0)').input('$data').enter('username2');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('username2');
 
     //click input --> no action, form shown
     element(s+'input[type="text"]').click();

--- a/docs/demos/dev-select/test.js
+++ b/docs/demos/dev-select/test.js
@@ -18,7 +18,7 @@ describe('dev-select-multiple', function() {
     expect(element(s+'form select option:selected').count()).toBe(2);
     expect(element(s+'form select').val()).toMatch('["1","3"]');
 
-    using(s).select('$data').option('status2');
+    using(s).select('$parent.$data').option('status2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a#multiSelect').css('display')).not().toBe('none');
@@ -40,7 +40,7 @@ describe('dev-select-multiple', function() {
     expect(element(s+'form select option:selected').count()).toBe(1);
     expect(element(s+'form select').val()).toMatch('');
 
-    using(s).select('$data').option('status2');
+    using(s).select('$parent.$data').option('status2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a#defaultValue').css('display')).not().toBe('none');

--- a/docs/demos/dev-text/test.js
+++ b/docs/demos/dev-text/test.js
@@ -45,7 +45,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
 
     element('body').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -56,7 +56,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form').count()).toBe(1);
-    using(s).input('$data').enter('username3');
+    using(s).input('$parent.$data').enter('username3');
 
     element(s+'a.cancel').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -72,7 +72,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
 
     element('body').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -83,7 +83,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form').count()).toBe(1);
-    using(s).input('$data').enter('username3');
+    using(s).input('$parent.$data').enter('username3');
 
     element(s+'a.ignore').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -99,7 +99,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
 
     element('body').click();
     expect(element(a).css('display')).toBe('none');

--- a/docs/demos/editable-column/test.js
+++ b/docs/demos/editable-column/test.js
@@ -65,9 +65,9 @@ describe('editable-column', function() {
     expect(element(s+'tr:eq(3) td:eq(0) .editable-error').text()).toMatch('Username should be `awesome`');
 
     //set correct values
-    using(s+'tr:eq(1) td:eq(0)').input('$data').enter('awesome');
-    using(s+'tr:eq(2) td:eq(0)').input('$data').enter('awesome');
-    using(s+'tr:eq(3) td:eq(0)').input('$data').enter('awesome');
+    using(s+'tr:eq(1) td:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'tr:eq(2) td:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'tr:eq(3) td:eq(0)').input('$parent.$data').enter('awesome');
 
     element(s+'tr:eq(0) td:eq(0) form button[type="submit"]').click();
 

--- a/docs/demos/editable-form/test.js
+++ b/docs/demos/editable-form/test.js
@@ -64,7 +64,7 @@ describe('editable-form', function() {
     sleep(delay);
 
     //set incorrect values (field's onbeforesave error)
-    using(s+'form > div:eq(0)').input('$data').enter('username2');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('username2');
     element(s+'.buttons > span button[type="submit"]').click();
 
     //error shown
@@ -75,7 +75,7 @@ describe('editable-form', function() {
     expect(element(s+'form > div:eq(0) .editable-error').text()).toMatch('Username should be `awesome`');
 
     //set incorrect values (form's onaftersave error)
-    using(s+'form > div:eq(0)').input('$data').enter('error');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('error');
     element(s+'.buttons > span button[type="submit"]').click();
 
     //saving
@@ -97,9 +97,9 @@ describe('editable-form', function() {
     expect(element(s+'form > div:eq(0) .editable-error').text()).toMatch('Server-side error');
 
     //set correct values
-    using(s+'form > div:eq(0)').input('$data').enter('awesome');
-    using(s+'form > div:eq(1)').select('$data').option('number:3'); //status4
-    using(s+'form > div:eq(2)').select('$data').option('number:1'); //user
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'form > div:eq(1)').select('$parent.$data').option('number:3'); //status4
+    using(s+'form > div:eq(2)').select('$parent.$data').option('number:1'); //user
 
     //click submit
     element(s+'.buttons > span button[type="submit"]').click();

--- a/docs/demos/editable-row/test.js
+++ b/docs/demos/editable-row/test.js
@@ -49,7 +49,7 @@ describe('editable-row', function() {
     checkShown();
 
     //set incorrect values
-    using(s+'td:eq(0)').input('$data').enter('username2');
+    using(s+'td:eq(0)').input('$parent.$data').enter('username2');
     element(s+'td:eq(3) form button[type="submit"]').click();
 
     checkShown();
@@ -59,9 +59,9 @@ describe('editable-row', function() {
     expect(element(s+'td:eq(0) .editable-error').text()).toMatch('Username 2 should be `awesome`');
 
     //set correct values
-    using(s+'td:eq(0)').input('$data').enter('awesome');
-    using(s+'td:eq(1)').select('$data').option('number:3'); //status4
-    using(s+'td:eq(2)').select('$data').option('number:1'); //user
+    using(s+'td:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'td:eq(1)').select('$parent.$data').option('number:3'); //status4
+    using(s+'td:eq(2)').select('$parent.$data').option('number:1'); //user
     element(s+'td:eq(3) form button[type="submit"]').click();
 
     checkWaiting();

--- a/docs/demos/editable-table/test.js
+++ b/docs/demos/editable-table/test.js
@@ -67,9 +67,9 @@ describe('editable-table', function() {
     expect(element(s+'table tr:eq(2) td:eq(0) .editable-error').text()).toMatch('Username 2 should be `awesome`');
 
     //set correct values
-    using(s+'table tr:eq(2) td:eq(0)').input('$data').enter('awesome'); //user2: name = awesome
-    using(s+'table tr:eq(1) td:eq(1)').select('$data').option('number:3'); //user1: status = status4
-    using(s+'table tr:eq(1) td:eq(2)').select('$data').option('number:1'); //user1: group = user
+    using(s+'table tr:eq(2) td:eq(0)').input('$parent.$data').enter('awesome'); //user2: name = awesome
+    using(s+'table tr:eq(1) td:eq(1)').select('$parent.$data').option('number:3'); //user1: status = status4
+    using(s+'table tr:eq(1) td:eq(2)').select('$parent.$data').option('number:1'); //user1: group = user
 
     //add 2 new rows
     expect(element(s+'table tr').count()).toBe(4);
@@ -112,9 +112,9 @@ describe('editable-table', function() {
     checkShown();
 
     //set correct values
-    using(s+'table tr:eq(2) td:eq(0)').input('$data').enter('awesome'); //user2: name = awesome
-    using(s+'table tr:eq(1) td:eq(1)').select('$data').option('number:3'); //user1: status = status4
-    using(s+'table tr:eq(1) td:eq(2)').select('$data').option('number:1'); //user1: group = user
+    using(s+'table tr:eq(2) td:eq(0)').input('$parent.$data').enter('awesome'); //user2: name = awesome
+    using(s+'table tr:eq(1) td:eq(1)').select('$parent.$data').option('number:3'); //user1: status = status4
+    using(s+'table tr:eq(1) td:eq(2)').select('$parent.$data').option('number:1'); //user1: group = user
 
     //add 2 new rows
     expect(element(s+'table tr').count()).toBe(4);

--- a/docs/demos/onaftersave/test.js
+++ b/docs/demos/onaftersave/test.js
@@ -11,7 +11,7 @@ describe('onaftersave', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('error');
+    using(s).input('$parent.$data').enter('error');
     element(s+'form button[type="submit"]').click();
 
     //local model changed
@@ -34,7 +34,7 @@ describe('onaftersave', function() {
     expect(element(s+'.editable-error').text()).toMatch('Server-side error');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     //local model changed

--- a/docs/demos/onbeforesave/test.js
+++ b/docs/demos/onbeforesave/test.js
@@ -11,7 +11,7 @@ describe('onbeforesave', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('error');
+    using(s).input('$parent.$data').enter('error');
     element(s+'form button[type="submit"]').click();
 
     //saving
@@ -31,7 +31,7 @@ describe('onbeforesave', function() {
     expect(element(s+'.editable-error').text()).toMatch('Server-side error');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     //saving

--- a/docs/demos/radiolist/test.js
+++ b/docs/demos/radiolist/test.js
@@ -14,11 +14,11 @@ describe('radiolist', function() {
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
     expect(element(s+'form input[type="radio"]:visible:enabled').count()).toBe(2);
 
-    expect(using(s+'label:eq(0)').input('$parent.$data').val()).toBe('1');
-    expect(using(s+'label:eq(1)').input('$parent.$data').val()).toBe('2');
+    expect(using(s+'label:eq(0)').input('$parent.$parent.$data').val()).toBe('1');
+    expect(using(s+'label:eq(1)').input('$parent.$parent.$data').val()).toBe('2');
 
     // select status1
-    using(s+'label:eq(0)').input('$parent.$data').select('1');
+    using(s+'label:eq(0)').input('$parent.$parent.$data').select('1');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/select-local/test.js
+++ b/docs/demos/select-local/test.js
@@ -17,7 +17,7 @@ describe('select-local', function() {
     //select uses own values in options!!
     expect(element(s+'form select').val()).toBe('number:2');
     
-    using(s).select('$data').option('2');
+    using(s).select('$parent.$data').option('2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/select-multiple/test.js
+++ b/docs/demos/select-multiple/test.js
@@ -18,7 +18,7 @@ describe('select-multiple', function() {
     expect(element(s+'form select option:selected').count()).toBe(2);
     expect(element(s+'form select').val()).toMatch('["1","3"]');
 
-    using(s).select('$data').options('number:2', 'number:3');
+    using(s).select('$parent.$data').options('number:2', 'number:3');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/select-nobuttons/test.js
+++ b/docs/demos/select-nobuttons/test.js
@@ -18,7 +18,7 @@ describe('select-nobuttons', function() {
     expect(element(s+'form select').val()).toBe('number:2');
 
     //set new value
-    using(s).select('$data').option('number:3');
+    using(s).select('$parent.$data').option('number:3');
 
     expect(element(s+'a').css('display')).not().toBe('none');
     expect(element(s+'a').text()).toMatch('status3');

--- a/docs/demos/select-remote/test.js
+++ b/docs/demos/select-remote/test.js
@@ -22,7 +22,7 @@ describe('select-remote', function() {
     expect(element(s+'button:visible').count()).toBe(2);
     expect(element(s+'form select').val()).toBe('number:4');
 
-    using(s).select('$data').option('number:3');
+    using(s).select('$parent.$data').option('number:3');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/text-btn/test.js
+++ b/docs/demos/text-btn/test.js
@@ -27,7 +27,7 @@ describe('text-btn', function() {
     expect(element(s+'form').attr('editable-form')).toBeTruthy();
 
     //submit
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'span:eq(0)').css('display')).not().toBe('none');

--- a/docs/demos/text-simple/test.js
+++ b/docs/demos/text-simple/test.js
@@ -18,7 +18,7 @@ describe('text-simple', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -30,7 +30,7 @@ describe('text-simple', function() {
     var s = '[ng-controller="TextSimpleCtrl"] ';
     element(s+'a').click();
 
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="button"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -53,7 +53,7 @@ describe('text-simple', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').enter('');
+    using(s).input('$parent.$data').enter('');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/textarea/test.js
+++ b/docs/demos/textarea/test.js
@@ -18,7 +18,7 @@ describe('textarea', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/typeahead/test.js
+++ b/docs/demos/typeahead/test.js
@@ -20,7 +20,7 @@ describe('typeahead', function() {
     expect(element(s+'form .editable-buttons button[type="button"]:visible').count()).toBe(1);
 
     //type 'a'
-    using(s).input('$data').enter('a');
+    using(s).input('$parent.$data').enter('a');
     expect(element(s+'form ul.dropdown-menu:visible').count()).toBe(1);
     expect(element(s+'form ul.dropdown-menu > li').count()).toBe(8);
 

--- a/docs/demos/validate-local/test.js
+++ b/docs/demos/validate-local/test.js
@@ -11,7 +11,7 @@ describe('validate-local', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('username');
+    using(s).input('$parent.$data').enter('username');
     element(s+'form button[type="submit"]').click();
 
     //form remains open
@@ -21,7 +21,7 @@ describe('validate-local', function() {
     expect(element(s+'.editable-error').text()).toMatch('Username should be `awesome`');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/validate-remote/test.js
+++ b/docs/demos/validate-remote/test.js
@@ -11,7 +11,7 @@ describe('validate-remote', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('username');
+    using(s).input('$parent.$data').enter('username');
     element(s+'form button[type="submit"]').click();
 
     //checking
@@ -30,7 +30,7 @@ describe('validate-remote', function() {
     expect(element(s+'.editable-error').text()).toMatch('Username should be `awesome`');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     //checking

--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -14,7 +14,7 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
                  **/
                 this.parent.render.call(this);
 
-                var inputDatePicker = angular.element('<input type="text" class="form-control" data-ng-model="$data"/>');
+                var inputDatePicker = angular.element('<input type="text" class="form-control" data-ng-model="$parent.$data"/>');
 
                 inputDatePicker.attr('uib-datepicker-popup', this.attrs.eDatepickerPopupXEditable || 'yyyy/MM/dd' );
                 inputDatePicker.attr('is-open', this.attrs.eIsOpen);

--- a/src/js/directives/checklist.js
+++ b/src/js/directives/checklist.js
@@ -11,7 +11,7 @@ angular.module('xeditable').directive('editableChecklist', [
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
         var html = '<label ng-repeat="'+parsed.ngRepeat+'">'+
-          '<input type="checkbox" checklist-model="$parent.$data" checklist-value="'+parsed.locals.valueFn+'">'+
+          '<input type="checkbox" checklist-model="$parent.$parent.$data" checklist-value="'+parsed.locals.valueFn+'">'+
           '<span ng-bind="'+parsed.locals.displayFn+'"></span></label>';
 
         this.inputEl.removeAttr('ng-model');

--- a/src/js/directives/radiolist.js
+++ b/src/js/directives/radiolist.js
@@ -10,7 +10,7 @@ angular.module('xeditable').directive('editableRadiolist', [
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
         var html = '<label ng-repeat="'+parsed.ngRepeat+'">'+
-          '<input type="radio" ng-disabled="' + this.attrs.eNgDisabled + '" ng-model="$parent.$data" value="{{'+parsed.locals.valueFn+'}}">'+
+          '<input type="radio" ng-disabled="' + this.attrs.eNgDisabled + '" ng-model="$parent.$parent.$data" value="{{'+parsed.locals.valueFn+'}}">'+
           '<span ng-bind="'+parsed.locals.displayFn+'"></span></label>';
 
         this.inputEl.removeAttr('ng-model');

--- a/src/js/directives/uiselect.js
+++ b/src/js/directives/uiselect.js
@@ -34,7 +34,7 @@ angular.module('xeditable').directive('editableUiSelect',['editableDirectiveFact
                 this.inputEl.append(rename('ui-select-match', match[index].element));
                 this.inputEl.append(rename('ui-select-choices', choices[index].element));
                 this.inputEl.removeAttr('ng-model');
-                this.inputEl.attr('ng-model', '$parent.$data');
+                this.inputEl.attr('ng-model', '$parent.$parent.$data');
             }
         });
 

--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -245,7 +245,7 @@ angular.module('xeditable').factory('editableController',
       }
 
       self.inputEl.addClass('editable-input');
-      self.inputEl.attr('ng-model', '$data');
+      self.inputEl.attr('ng-model', '$parent.$data');
 
       // add directiveName class to editor, e.g. `editable-text`
       self.editorEl.addClass(editableUtils.camelToDash(self.directiveName));
@@ -272,6 +272,8 @@ angular.module('xeditable').factory('editableController',
         valueGetter($scope.$parent);
     };
 
+    // reference of the scope to use for $compile
+    var newScope = null;
     //show
     self.show = function() {
       // set value of scope.$data
@@ -288,7 +290,8 @@ angular.module('xeditable').factory('editableController',
       $element.after(self.editorEl);
 
       // compile (needed to attach ng-* events from markup)
-      $compile(self.editorEl)($scope);
+      newScope = $scope.$new();
+      $compile(self.editorEl)(newScope);
 
       // attach listeners (`escape`, autosubmit, etc)
       self.addListeners();
@@ -302,6 +305,9 @@ angular.module('xeditable').factory('editableController',
 
     //hide
     self.hide = function() {
+
+      // destroy the scope to prevent memory leak
+      newScope.$destroy();
 
       self.controlsEl.remove();
       self.editorEl.remove();


### PR DESCRIPTION
This merge request probably solves Issue #364 . Currently when entering the `editable` mode, the `element` is `$compile`d with the same `$scope` as before and is not being destroyed properly when exiting `editable` mode.  This fix is the same fix made in issue #158 but the merge request hasn't been accepted due to other problems ( i'm not sure why ).
  I think this memory leak is fatal for pages which use many inputs on the same page (it'll create lots of `$$watchers` every time entering `editable` mode).  I'm not quite sure about the side effects so it would be very helpful if somebody could point any problems about this change.

Thanks in advance.

**Edited**
It seems this same fix has been removed due to the fix of issue #265 .  I'll have to take a look at the issue a little more.