### PR TITLE
Added popover functionality

### DIFF
--- a/docs/demos/checkbox/test.js
+++ b/docs/demos/checkbox/test.js
@@ -17,7 +17,7 @@ describe('checkbox', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').check();
+    using(s).input('$parent.$data').check();
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a:visible').count()).toBe(1);

--- a/docs/demos/dev-form/test.js
+++ b/docs/demos/dev-form/test.js
@@ -58,7 +58,7 @@ describe('dev-form', function() {
     expect(element(s+'input[type="text"]:enabled:visible').count()).toBe(1);
 
     //set some value
-    using(s+'form > div:eq(0)').input('$data').enter('username2');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('username2');
 
     //click input --> no action, form shown
     element(s+'input[type="text"]').click();
@@ -93,7 +93,7 @@ describe('dev-form', function() {
     expect(element(s+'input[type="text"]:enabled:visible').count()).toBe(1);
 
     //set some value
-    using(s+'form > div:eq(0)').input('$data').enter('username2');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('username2');
 
     //click input --> no action, form shown
     element(s+'input[type="text"]').click();

--- a/docs/demos/dev-select/test.js
+++ b/docs/demos/dev-select/test.js
@@ -18,7 +18,7 @@ describe('dev-select-multiple', function() {
     expect(element(s+'form select option:selected').count()).toBe(2);
     expect(element(s+'form select').val()).toMatch('["1","3"]');
 
-    using(s).select('$data').option('status2');
+    using(s).select('$parent.$data').option('status2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a#multiSelect').css('display')).not().toBe('none');
@@ -40,7 +40,7 @@ describe('dev-select-multiple', function() {
     expect(element(s+'form select option:selected').count()).toBe(1);
     expect(element(s+'form select').val()).toMatch('');
 
-    using(s).select('$data').option('status2');
+    using(s).select('$parent.$data').option('status2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a#defaultValue').css('display')).not().toBe('none');

--- a/docs/demos/dev-text/test.js
+++ b/docs/demos/dev-text/test.js
@@ -45,7 +45,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
 
     element('body').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -56,7 +56,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form').count()).toBe(1);
-    using(s).input('$data').enter('username3');
+    using(s).input('$parent.$data').enter('username3');
 
     element(s+'a.cancel').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -72,7 +72,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
 
     element('body').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -83,7 +83,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form').count()).toBe(1);
-    using(s).input('$data').enter('username3');
+    using(s).input('$parent.$data').enter('username3');
 
     element(s+'a.ignore').click();
     expect(element(a).css('display')).not().toBe('none');
@@ -99,7 +99,7 @@ describe('dev-text', function() {
     element(a).click();
     expect(element(a).css('display')).toBe('none');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
 
     element('body').click();
     expect(element(a).css('display')).toBe('none');

--- a/docs/demos/dev-uiselect/controller.js
+++ b/docs/demos/dev-uiselect/controller.js
@@ -1,8 +1,11 @@
 app.controller('DevUiSelectCtrl', function($scope) {
   $scope.user = {
     state: 'Arizona',
-    state2: 'Kansas'
+    state2: 'Kansas',
+    tag: []
   };
 
   $scope.states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
+
+  $scope.tags = ['JavaScript', 'Angular', 'TypeScript'];
 });

--- a/docs/demos/dev-uiselect/test.js
+++ b/docs/demos/dev-uiselect/test.js
@@ -9,19 +9,19 @@ describe('uiselect', function() {
 
     //edit button initially shown, form initially hidden
     expect(element(s+'div#state:visible').count()).toBe(1);
-    expect(element(s+'.buttons > button:visible').count()).toBe(1);
+    expect(element(s+'.buttons > button:visible').count()).toBe(2);
     expect(element(s+'.buttons > span:visible').count()).toBe(0);
 
     //show form
-    element(s+'form > div > button').click();
+    element(s+'form[name=uiSelectForm] > div > button').click();
     //second click to test that controls not duplicated!
-    element(s+'form > div > button').click();
+    element(s+'form[name=uiSelectForm] > div > button').click();
     //also click outside to check blur = ignore
     element('body').click();
 
     //form shown in disabled state (loading)
-    expect(element(s+'div#name:visible').count()).toBe(0);
-    expect(element(s+'.buttons > button:visible').count()).toBe(0);
+    expect(element(s+'div#state:visible').count()).toBe(0);
+    expect(element(s+'.buttons > button:visible').count()).toBe(1);
 
     sleep(delay);
 
@@ -30,15 +30,15 @@ describe('uiselect', function() {
 
     //form enabled when data loaded
     expect(element(s+'div#state:visible').count()).toBe(0);
-    expect(element(s+'.buttons > button:visible').count()).toBe(0);
-    expect(element(s+'.buttons > span button:enabled').count()).toBe(2);
+    expect(element(s+'.buttons > button:visible').count()).toBe(1);
+    expect(element(s+'.buttons > span button:enabled').count()).toBe(4);
 
     //click cancel
-    element(s+'form > div > span button[type="button"]').click();
+    element(s+'form[name=uiSelectForm] > div > span button[type="button"]').click();
 
     //form closed
     expect(element(s+'div#state:visible').count()).toBe(1);
-    expect(element(s+'.buttons > button:visible').count()).toBe(1);
+    expect(element(s+'.buttons > button:visible').count()).toBe(2);
     expect(element(s+'.buttons > span:visible').count()).toBe(0);
   });
 
@@ -46,7 +46,7 @@ describe('uiselect', function() {
     var s = '[ng-controller="DevUiSelectCtrl"] ';
 
     //show form
-    element(s+'form > div > button').click();
+    element(s+'form[name=uiSelectForm] > div > button').click();
 
     sleep(delay);
 
@@ -61,12 +61,12 @@ describe('uiselect', function() {
     element(s+'#ui-select-choices-row-1-').click();
 
     //click submit
-    element(s+'span button[type="submit"]').click();
+    element(s+'span button[name="submitState"]').click();
     //second click to check that it works correctly
-    element(s+'span button[type="submit"]').click();
+    element(s+'span button[name="submitState"]').click();
 
     //saving
-    expect(element(s+'form > div:eq(0) .editable-error:visible').count()).toBe(0);
+    expect(element(s+'form[name=uiSelectForm] > div:eq(0) .editable-error:visible').count()).toBe(0);
 
     sleep(delay);
 
@@ -75,8 +75,98 @@ describe('uiselect', function() {
     expect(element(s+'div#state:visible').text()).toMatch('Illinois');
     expect(element(s+'div#state2:visible').count()).toBe(1);
     expect(element(s+'div#state2:visible').text()).toMatch('Arizona');
-    expect(element(s+'.buttons > button:visible').count()).toBe(1);
+    expect(element(s+'.buttons > button:visible').count()).toBe(2);
     expect(element(s+'.buttons > span:visible').count()).toBe(0);
   });
 
+
+  it('should show form by `edit` button click and close by `cancel` for tag select', function() {
+    var s = '[ng-controller="DevUiSelectCtrl"] ';
+
+    //edit button initially shown, form initially hidden
+    expect(element(s+'div#tag:visible').count()).toBe(1);
+    expect(element(s+'.buttons > button:visible').count()).toBe(2);
+    expect(element(s+'.buttons > span:visible').count()).toBe(0);
+
+    //show form
+    element(s+'form[name=uiTagsform] > div > button').click();
+    //second click to test that controls not duplicated!
+    element(s+'form[name=uiTagsform]  > div > button').click();
+    //also click outside to check blur = ignore
+    element('body').click();
+
+    //form shown in disabled state (loading)
+    expect(element(s+'div#tag:visible').count()).toBe(0);
+    expect(element(s+'.buttons > button:visible').count()).toBe(1);
+
+    sleep(delay);
+
+    //also click outside to check blur = ignore
+    element('body').click();
+
+    //form enabled when data loaded
+    expect(element(s+'div#tag:visible').count()).toBe(0);
+    expect(element(s+'.buttons > button:visible').count()).toBe(1);
+    expect(element(s+'.buttons > span button:enabled').count()).toBe(4);
+
+    //click cancel
+    element(s+'form[name=uiTagsform]  > div > span button[type="button"]').click();
+
+    //form closed
+    expect(element(s+'div#tag:visible').count()).toBe(1);
+    expect(element(s+'.buttons > button:visible').count()).toBe(2);
+    expect(element(s+'.buttons > span:visible').count()).toBe(0);
+  });
+
+  it('should show form and save new values for tag select', function() {
+    var s = '[ng-controller="DevUiSelectCtrl"] ';
+
+    //show form
+    element(s+'form[name=uiSelectForm] > div > button').click();
+    element(s+'form[name=uiTagsform] > div > button').click();
+
+    sleep(delay);
+
+    //select a value for the first dropdown
+    element(s+'div[name=state] > div > span').click();
+    input('$select.search').enter('Illinois');
+    element(s+'#ui-select-choices-row-0-').click();
+
+    //select a value for the second dropdown
+    element(s+'div[name=state2] > div > span').click();
+    input('$select.search').enter('Arizona');
+    element(s+'#ui-select-choices-row-1-').click();
+
+    //select a value for the tag dropdown
+    element(s+'div[name=tag] > div > span').click();
+    input('$select.search').enter('Angular');
+    element(s+'#ui-select-choices-row-2-').click();
+
+    //click submit for state form
+    element(s+'span button[name="submitState"]').click();
+    //second click to check that it works correctly
+    element(s+'span button[name="submitState"]').click();
+
+
+    //click submit for tag form
+    element(s+'span button[name="submitTag"]').click();
+    //second click to check that it works correctly
+    element(s+'span button[name="submitTag"]').click();
+
+    //saving
+    expect(element(s+'form[name=uiTagsform] > div:eq(0) .editable-error:visible').count()).toBe(0);
+    expect(element(s+'form[name=uiSelectForm] > div:eq(0) .editable-error:visible').count()).toBe(0);
+
+    sleep(delay);
+
+    //form closed, new values shown
+    expect(element(s+'div#state:visible').count()).toBe(1);
+    expect(element(s+'div#state:visible').text()).toMatch('Illinois');
+    expect(element(s+'div#state2:visible').count()).toBe(1);
+    expect(element(s+'div#state2:visible').text()).toMatch('Arizona');
+    expect(element(s+'div#tag:visible').count()).toBe(1);
+    expect(element(s+'div#tag:visible').text()).toMatch('Angular');
+    expect(element(s+'.buttons > button:visible').count()).toBe(2);
+    expect(element(s+'.buttons > span:visible').count()).toBe(0);
+  });
 });

--- a/docs/demos/dev-uiselect/view.html
+++ b/docs/demos/dev-uiselect/view.html
@@ -27,10 +27,39 @@
       <!-- buttons to submit / cancel form -->
       <span ng-show="uiSelectForm.$visible">
         <br/>
-        <button type="submit" class="btn btn-primary" ng-disabled="uiSelectForm.$waiting">
+        <button type="submit" class="btn btn-primary" name="submitState" ng-disabled="uiSelectForm.$waiting">
           Save
         </button>
         <button type="button" class="btn btn-default" ng-disabled="uiSelectForm.$waiting" ng-click="uiSelectForm.$cancel()">
+          Cancel
+        </button>
+      </span>
+    </div>
+  </form>
+
+  <form data-editable-form name="uiTagsform">
+    <div editable-ui-select="user.tag" data-e-form="uiTagsform" data-e-name="tag" name="tag" id="tag" theme="bootstrap" data-e-tagging data-e-ng-model="user.tag">
+      {{user.tag}}
+      <editable-ui-select-match placeholder="Tags">
+        {{$select.selected}}
+      </editable-ui-select-match>
+      <editable-ui-select-choices repeat="tag in tags | filter: $select.search track by $index">
+        {{tag}}
+      </editable-ui-select-choices>
+    </div>
+    <br/>
+    <div class="buttons">
+      <!-- button to show form -->
+      <button type="button" class="btn btn-default" ng-click="uiTagsform.$show()" ng-show="!uiTagsform.$visible">
+        Edit
+      </button>
+      <!-- buttons to submit / cancel form -->
+      <span ng-show="uiTagsform.$visible">
+        <br/>
+        <button type="submit" class="btn btn-primary" name="submitTag" ng-disabled="uiTagsform.$waiting">
+          Save
+        </button>
+        <button type="button" class="btn btn-default" ng-disabled="uiTagsform.$waiting" ng-click="uiTagsform.$cancel()">
           Cancel
         </button>
       </span>

--- a/docs/demos/editable-column/test.js
+++ b/docs/demos/editable-column/test.js
@@ -65,9 +65,9 @@ describe('editable-column', function() {
     expect(element(s+'tr:eq(3) td:eq(0) .editable-error').text()).toMatch('Username should be `awesome`');
 
     //set correct values
-    using(s+'tr:eq(1) td:eq(0)').input('$data').enter('awesome');
-    using(s+'tr:eq(2) td:eq(0)').input('$data').enter('awesome');
-    using(s+'tr:eq(3) td:eq(0)').input('$data').enter('awesome');
+    using(s+'tr:eq(1) td:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'tr:eq(2) td:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'tr:eq(3) td:eq(0)').input('$parent.$data').enter('awesome');
 
     element(s+'tr:eq(0) td:eq(0) form button[type="submit"]').click();
 

--- a/docs/demos/editable-form/desc.md
+++ b/docs/demos/editable-form/desc.md
@@ -49,4 +49,6 @@ The result of form's `onaftersave` is also important for next step:
 
 Commonly you should define `onbeforesave` for child elements to perform validation and `onaftersave` for whole form to send data on server.
 
+Note:  `e-required` will not work since HTML5 validation only works if submitting a form with a submit button and `editable-form` submits via a script.
+
 Please have a look at examples.

--- a/docs/demos/editable-form/test.js
+++ b/docs/demos/editable-form/test.js
@@ -64,7 +64,7 @@ describe('editable-form', function() {
     sleep(delay);
 
     //set incorrect values (field's onbeforesave error)
-    using(s+'form > div:eq(0)').input('$data').enter('username2');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('username2');
     element(s+'.buttons > span button[type="submit"]').click();
 
     //error shown
@@ -75,7 +75,7 @@ describe('editable-form', function() {
     expect(element(s+'form > div:eq(0) .editable-error').text()).toMatch('Username should be `awesome`');
 
     //set incorrect values (form's onaftersave error)
-    using(s+'form > div:eq(0)').input('$data').enter('error');
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('error');
     element(s+'.buttons > span button[type="submit"]').click();
 
     //saving
@@ -97,9 +97,9 @@ describe('editable-form', function() {
     expect(element(s+'form > div:eq(0) .editable-error').text()).toMatch('Server-side error');
 
     //set correct values
-    using(s+'form > div:eq(0)').input('$data').enter('awesome');
-    using(s+'form > div:eq(1)').select('$data').option('number:3'); //status4
-    using(s+'form > div:eq(2)').select('$data').option('number:1'); //user
+    using(s+'form > div:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'form > div:eq(1)').select('$parent.$data').option('number:3'); //status4
+    using(s+'form > div:eq(2)').select('$parent.$data').option('number:1'); //user
 
     //click submit
     element(s+'.buttons > span button[type="submit"]').click();

--- a/docs/demos/editable-popover/controller.js
+++ b/docs/demos/editable-popover/controller.js
@@ -1,0 +1,5 @@
+app.controller('EditPopoverCtrl', function($scope) {
+  $scope.user = {
+    name: 'awesome user'
+  };  
+});

--- a/docs/demos/editable-popover/desc.md
+++ b/docs/demos/editable-popover/desc.md
@@ -1,0 +1,1 @@
+To made an editable field display in a popover, wrap the editable in `<div class="item-wrapper">`.

--- a/docs/demos/editable-popover/test.js
+++ b/docs/demos/editable-popover/test.js
@@ -1,24 +1,25 @@
-describe('text-simple', function() {
+describe('editable-popover', function() {
 
   beforeEach(function() {
     browser().navigateTo(mainUrl);
   });
 
+
   it('should show editor and submit new value', function() {
-    var s = '[ng-controller="TextSimpleCtrl"] ';
+    var s = '[ng-controller="EditPopoverCtrl"] ';
 
     expect(element(s+'a').css('display')).not().toBe('none');
     expect(element(s+'a').text()).toMatch('awesome user');
     element(s+'a').click();
 
-    expect(element(s+'a').css('display')).toBe('none');
+    expect(element(s+'a').css('display')).toBe('inline');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
     expect(element(s+'form input[type="text"]:visible').count()).toBe(1);
     expect(element(s+'form input[type="text"]').val()).toBe('awesome user');
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$parent.$data').enter('username2');
+    using(s).input('$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -27,10 +28,10 @@ describe('text-simple', function() {
   });
 
   it('should not save by cancel button', function() {
-    var s = '[ng-controller="TextSimpleCtrl"] ';
+    var s = '[ng-controller="EditPopoverCtrl"] ';
     element(s+'a').click();
 
-    using(s).input('$parent.$data').enter('username2');
+    using(s).input('$data').enter('username2');
     element(s+'form button[type="button"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -39,21 +40,21 @@ describe('text-simple', function() {
   });
 
   it('should attach `editable-empty` class', function() {
-    var s = '[ng-controller="TextSimpleCtrl"] ';
+    var s = '[ng-controller="EditPopoverCtrl"] ';
 
     expect(element(s+'a').css('display')).not().toBe('none');
     expect(element(s+'a').text()).toMatch('awesome user');
     expect(element(s+'a').attr('class')).not().toMatch('editable-empty');
     element(s+'a').click();
 
-    expect(element(s+'a').css('display')).toBe('none');
+    expect(element(s+'a').css('display')).toBe('inline');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
     expect(element(s+'form input[type="text"]:visible').count()).toBe(1);
     expect(element(s+'form input[type="text"]').val()).toBe('awesome user');
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$parent.$data').enter('');
+    using(s).input('$data').enter('');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -63,16 +64,16 @@ describe('text-simple', function() {
   });
 
   it('should cancel by click on body', function() {
-    var s = '[ng-controller="TextSimpleCtrl"] ';
+    var s = '[ng-controller="EditPopoverCtrl"] ';
     element(s+'a').click();
 
-    expect(element(s+'a').css('display')).toBe('none');
+    expect(element(s+'a').css('display')).toBe('inline');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
     expect(element(s+'form input[type="text"]:visible').count()).toBe(1);
 
     // click on input - still visible
     element(s+'form input[type="text"]').click();
-    expect(element(s+'a').css('display')).toBe('none');
+    expect(element(s+'a').css('display')).toBe('inline');
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
     expect(element(s+'form input[type="text"]:visible').count()).toBe(1);
 

--- a/docs/demos/editable-popover/view.html
+++ b/docs/demos/editable-popover/view.html
@@ -1,0 +1,5 @@
+<div ng-controller="EditPopoverCtrl">
+  <div class="popover-wrapper">
+    <a href="#" editable-text="user.name">{{user.name || 'empty' }}</a>
+  </div>
+</div>

--- a/docs/demos/editable-row/test.js
+++ b/docs/demos/editable-row/test.js
@@ -49,7 +49,7 @@ describe('editable-row', function() {
     checkShown();
 
     //set incorrect values
-    using(s+'td:eq(0)').input('$data').enter('username2');
+    using(s+'td:eq(0)').input('$parent.$data').enter('username2');
     element(s+'td:eq(3) form button[type="submit"]').click();
 
     checkShown();
@@ -59,9 +59,9 @@ describe('editable-row', function() {
     expect(element(s+'td:eq(0) .editable-error').text()).toMatch('Username 2 should be `awesome`');
 
     //set correct values
-    using(s+'td:eq(0)').input('$data').enter('awesome');
-    using(s+'td:eq(1)').select('$data').option('number:3'); //status4
-    using(s+'td:eq(2)').select('$data').option('number:1'); //user
+    using(s+'td:eq(0)').input('$parent.$data').enter('awesome');
+    using(s+'td:eq(1)').select('$parent.$data').option('number:3'); //status4
+    using(s+'td:eq(2)').select('$parent.$data').option('number:1'); //user
     element(s+'td:eq(3) form button[type="submit"]').click();
 
     checkWaiting();

--- a/docs/demos/editable-row/view.html
+++ b/docs/demos/editable-row/view.html
@@ -9,7 +9,7 @@
     <tr ng-repeat="user in users">
       <td>
         <!-- editable username (text with validation) -->
-        <span editable-text="user.name" e-name="name" e-form="rowform" onbeforesave="checkName($data, user.id)" e-required>
+        <span editable-text="user.name" e-name="name" e-form="rowform" onbeforesave="checkName($data, user.id)">
           {{ user.name || 'empty' }}
         </span>
       </td>

--- a/docs/demos/editable-table/test.js
+++ b/docs/demos/editable-table/test.js
@@ -67,9 +67,9 @@ describe('editable-table', function() {
     expect(element(s+'table tr:eq(2) td:eq(0) .editable-error').text()).toMatch('Username 2 should be `awesome`');
 
     //set correct values
-    using(s+'table tr:eq(2) td:eq(0)').input('$data').enter('awesome'); //user2: name = awesome
-    using(s+'table tr:eq(1) td:eq(1)').select('$data').option('number:3'); //user1: status = status4
-    using(s+'table tr:eq(1) td:eq(2)').select('$data').option('number:1'); //user1: group = user
+    using(s+'table tr:eq(2) td:eq(0)').input('$parent.$data').enter('awesome'); //user2: name = awesome
+    using(s+'table tr:eq(1) td:eq(1)').select('$parent.$data').option('number:3'); //user1: status = status4
+    using(s+'table tr:eq(1) td:eq(2)').select('$parent.$data').option('number:1'); //user1: group = user
 
     //add 2 new rows
     expect(element(s+'table tr').count()).toBe(4);
@@ -112,9 +112,9 @@ describe('editable-table', function() {
     checkShown();
 
     //set correct values
-    using(s+'table tr:eq(2) td:eq(0)').input('$data').enter('awesome'); //user2: name = awesome
-    using(s+'table tr:eq(1) td:eq(1)').select('$data').option('number:3'); //user1: status = status4
-    using(s+'table tr:eq(1) td:eq(2)').select('$data').option('number:1'); //user1: group = user
+    using(s+'table tr:eq(2) td:eq(0)').input('$parent.$data').enter('awesome'); //user2: name = awesome
+    using(s+'table tr:eq(1) td:eq(1)').select('$parent.$data').option('number:3'); //user1: status = status4
+    using(s+'table tr:eq(1) td:eq(2)').select('$parent.$data').option('number:1'); //user1: group = user
 
     //add 2 new rows
     expect(element(s+'table tr').count()).toBe(4);

--- a/docs/demos/onaftersave/test.js
+++ b/docs/demos/onaftersave/test.js
@@ -11,7 +11,7 @@ describe('onaftersave', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('error');
+    using(s).input('$parent.$data').enter('error');
     element(s+'form button[type="submit"]').click();
 
     //local model changed
@@ -34,7 +34,7 @@ describe('onaftersave', function() {
     expect(element(s+'.editable-error').text()).toMatch('Server-side error');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     //local model changed

--- a/docs/demos/onbeforesave/test.js
+++ b/docs/demos/onbeforesave/test.js
@@ -11,7 +11,7 @@ describe('onbeforesave', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('error');
+    using(s).input('$parent.$data').enter('error');
     element(s+'form button[type="submit"]').click();
 
     //saving
@@ -31,7 +31,7 @@ describe('onbeforesave', function() {
     expect(element(s+'.editable-error').text()).toMatch('Server-side error');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     //saving

--- a/docs/demos/radiolist/test.js
+++ b/docs/demos/radiolist/test.js
@@ -14,11 +14,11 @@ describe('radiolist', function() {
     expect(element(s+'form[editable-form="$form"]').count()).toBe(1);
     expect(element(s+'form input[type="radio"]:visible:enabled').count()).toBe(2);
 
-    expect(using(s+'label:eq(0)').input('$parent.$data').val()).toBe('1');
-    expect(using(s+'label:eq(1)').input('$parent.$data').val()).toBe('2');
+    expect(using(s+'label:eq(0)').input('$parent.$parent.$data').val()).toBe('1');
+    expect(using(s+'label:eq(1)').input('$parent.$parent.$data').val()).toBe('2');
 
     // select status1
-    using(s+'label:eq(0)').input('$parent.$data').select('1');
+    using(s+'label:eq(0)').input('$parent.$parent.$data').select('1');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/radiolist/view.html
+++ b/docs/demos/radiolist/view.html
@@ -1,5 +1,5 @@
 <div ng-controller="RadiolistCtrl">
-  <a href="#" editable-radiolist="user.status" e-ng-options="s.value as s.text for s in statuses">
+  <a href="#" editable-radiolist="user.status" e-ng-options="s.value as s.text for s in ::statuses track by s.value">
     {{ showStatus() }}
   </a>
 </div>  

--- a/docs/demos/select-local/test.js
+++ b/docs/demos/select-local/test.js
@@ -17,7 +17,7 @@ describe('select-local', function() {
     //select uses own values in options!!
     expect(element(s+'form select').val()).toBe('number:2');
     
-    using(s).select('$data').option('2');
+    using(s).select('$parent.$data').option('2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/select-multiple/test.js
+++ b/docs/demos/select-multiple/test.js
@@ -18,7 +18,7 @@ describe('select-multiple', function() {
     expect(element(s+'form select option:selected').count()).toBe(2);
     expect(element(s+'form select').val()).toMatch('["1","3"]');
 
-    using(s).select('$data').options('number:2', 'number:3');
+    using(s).select('$parent.$data').options('number:2', 'number:3');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/select-nobuttons/test.js
+++ b/docs/demos/select-nobuttons/test.js
@@ -18,7 +18,7 @@ describe('select-nobuttons', function() {
     expect(element(s+'form select').val()).toBe('number:2');
 
     //set new value
-    using(s).select('$data').option('number:3');
+    using(s).select('$parent.$data').option('number:3');
 
     expect(element(s+'a').css('display')).not().toBe('none');
     expect(element(s+'a').text()).toMatch('status3');

--- a/docs/demos/select-remote/test.js
+++ b/docs/demos/select-remote/test.js
@@ -22,7 +22,7 @@ describe('select-remote', function() {
     expect(element(s+'button:visible').count()).toBe(2);
     expect(element(s+'form select').val()).toBe('number:4');
 
-    using(s).select('$data').option('number:3');
+    using(s).select('$parent.$data').option('number:3');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/text-btn/test.js
+++ b/docs/demos/text-btn/test.js
@@ -27,7 +27,7 @@ describe('text-btn', function() {
     expect(element(s+'form').attr('editable-form')).toBeTruthy();
 
     //submit
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'span:eq(0)').css('display')).not().toBe('none');

--- a/docs/demos/text-simple/test.js
+++ b/docs/demos/text-simple/test.js
@@ -18,7 +18,7 @@ describe('text-simple', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -30,7 +30,7 @@ describe('text-simple', function() {
     var s = '[ng-controller="TextSimpleCtrl"] ';
     element(s+'a').click();
 
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="button"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');
@@ -53,7 +53,7 @@ describe('text-simple', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').enter('');
+    using(s).input('$parent.$data').enter('');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/textarea/test.js
+++ b/docs/demos/textarea/test.js
@@ -18,7 +18,7 @@ describe('textarea', function() {
     expect(element(s+'form button[type="submit"]:visible').count()).toBe(1);
     expect(element(s+'form button[type="button"]:visible').count()).toBe(1);
 
-    using(s).input('$data').enter('username2');
+    using(s).input('$parent.$data').enter('username2');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/typeahead/test.js
+++ b/docs/demos/typeahead/test.js
@@ -20,7 +20,7 @@ describe('typeahead', function() {
     expect(element(s+'form .editable-buttons button[type="button"]:visible').count()).toBe(1);
 
     //type 'a'
-    using(s).input('$data').enter('a');
+    using(s).input('$parent.$data').enter('a');
     expect(element(s+'form ul.dropdown-menu:visible').count()).toBe(1);
     expect(element(s+'form ul.dropdown-menu > li').count()).toBe(8);
 

--- a/docs/demos/validate-local/test.js
+++ b/docs/demos/validate-local/test.js
@@ -11,7 +11,7 @@ describe('validate-local', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('username');
+    using(s).input('$parent.$data').enter('username');
     element(s+'form button[type="submit"]').click();
 
     //form remains open
@@ -21,7 +21,7 @@ describe('validate-local', function() {
     expect(element(s+'.editable-error').text()).toMatch('Username should be `awesome`');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     expect(element(s+'a').css('display')).not().toBe('none');

--- a/docs/demos/validate-remote/test.js
+++ b/docs/demos/validate-remote/test.js
@@ -11,7 +11,7 @@ describe('validate-remote', function() {
     element(s+'a').click();
 
     //not valid
-    using(s).input('$data').enter('username');
+    using(s).input('$parent.$data').enter('username');
     element(s+'form button[type="submit"]').click();
 
     //checking
@@ -30,7 +30,7 @@ describe('validate-remote', function() {
     expect(element(s+'.editable-error').text()).toMatch('Username should be `awesome`');
 
     //valid
-    using(s).input('$data').enter('awesome');
+    using(s).input('$parent.$data').enter('awesome');
     element(s+'form button[type="submit"]').click();
 
     //checking

--- a/docs/js/structure.js
+++ b/docs/js/structure.js
@@ -24,7 +24,8 @@ module.exports = [
         {id: 'select-multiple', text: 'Select multiple', fiddle: 'http://jsfiddle.net/NfPcH/30/'},
         {id: 'validate-local', text: 'Validate local', fiddle: 'http://jsfiddle.net/NfPcH/35/'},
         {id: 'validate-remote', text: 'Validate remote', fiddle: 'http://jsfiddle.net/NfPcH/36/'},
-        {id: 'edit-disabled', text: 'Disable editing'}
+        {id: 'edit-disabled', text: 'Disable editing'},
+        {id: 'editable-popover', text: 'Editable Popover'}
     ]},
 
     {id: 'onbeforesave', text: 'Submit', type: 'demos', items: [

--- a/src/css/xeditable.css
+++ b/src/css/xeditable.css
@@ -113,4 +113,53 @@ a.editable-empty:focus {
   text-decoration: none;
 }
 
+/* editable popover */
+.popover-wrapper a {
+  /* make the link always show up */
+  display: inline !important;
+}
+
+.popover-wrapper {
+  /* make absolutely positioned children constrained to this box*/
+  display: inline;
+  position: relative;
+}
+
+.popover-wrapper form {
+  position: absolute;
+  top: -53px;
+  background: #FFF;
+  border: 1px solid #AAA;
+  border-radius: 5px;
+  padding: 7px;
+  width: auto;
+  display: inline-block;
+  left: 50%;
+  margin-left: -110px;
+  z-index: 101;
+}
+
+.popover-wrapper form:before {
+  content:"";
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid #AAA;
+  position:absolute;
+  bottom:-10px;
+  left:100px;
+}
+
+.popover-wrapper form:after {
+  content:"";
+  width:0;
+  height:0;
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-top: 9px solid #FFF;
+  position:absolute;
+  bottom:-9px;
+  left:101px;
+}
 

--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -14,7 +14,7 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
                  **/
                 this.parent.render.call(this);
 
-                var inputDatePicker = angular.element('<input type="text" class="form-control" data-ng-model="$data"/>');
+                var inputDatePicker = angular.element('<input type="text" class="form-control" data-ng-model="$parent.$data"/>');
 
                 inputDatePicker.attr('uib-datepicker-popup', this.attrs.eDatepickerPopupXEditable || 'yyyy/MM/dd' );
                 inputDatePicker.attr('is-open', this.attrs.eIsOpen);

--- a/src/js/directives/checklist.js
+++ b/src/js/directives/checklist.js
@@ -11,7 +11,7 @@ angular.module('xeditable').directive('editableChecklist', [
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
         var html = '<label ng-repeat="'+parsed.ngRepeat+'">'+
-          '<input type="checkbox" checklist-model="$parent.$data" checklist-value="'+parsed.locals.valueFn+'">'+
+          '<input type="checkbox" checklist-model="$parent.$parent.$data" checklist-value="'+parsed.locals.valueFn+'">'+
           '<span ng-bind="'+parsed.locals.displayFn+'"></span></label>';
 
         this.inputEl.removeAttr('ng-model');

--- a/src/js/directives/radiolist.js
+++ b/src/js/directives/radiolist.js
@@ -10,7 +10,7 @@ angular.module('xeditable').directive('editableRadiolist', [
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
         var html = '<label ng-repeat="'+parsed.ngRepeat+'">'+
-          '<input type="radio" ng-disabled="' + this.attrs.eNgDisabled + '" ng-model="$parent.$data" value="{{'+parsed.locals.valueFn+'}}">'+
+          '<input type="radio" ng-disabled="' + this.attrs.eNgDisabled + '" ng-model="$parent.$parent.$data" value="{{'+parsed.locals.valueFn+'}}">'+
           '<span ng-bind="'+parsed.locals.displayFn+'"></span></label>';
 
         this.inputEl.removeAttr('ng-model');

--- a/src/js/directives/radiolist.js
+++ b/src/js/directives/radiolist.js
@@ -9,7 +9,6 @@ angular.module('xeditable').directive('editableRadiolist', [
       render: function() {
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
-
         var html = '<label data-ng-repeat="'+parsed.ngRepeat+'">'+
           '<input type="radio" data-ng-disabled="::' + this.attrs.eNgDisabled + '" data-ng-model="$parent.$parent.$data" value="{{::'+parsed.locals.valueFn+'}}">'+
           '<span data-ng-bind="::'+parsed.locals.displayFn+'"></span></label>';

--- a/src/js/directives/radiolist.js
+++ b/src/js/directives/radiolist.js
@@ -9,6 +9,7 @@ angular.module('xeditable').directive('editableRadiolist', [
       render: function() {
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
+        
         var html = '<label data-ng-repeat="'+parsed.ngRepeat+'">'+
           '<input type="radio" data-ng-disabled="::' + this.attrs.eNgDisabled + '" data-ng-model="$parent.$parent.$data" value="{{::'+parsed.locals.valueFn+'}}">'+
           '<span data-ng-bind="::'+parsed.locals.displayFn+'"></span></label>';

--- a/src/js/directives/radiolist.js
+++ b/src/js/directives/radiolist.js
@@ -9,9 +9,10 @@ angular.module('xeditable').directive('editableRadiolist', [
       render: function() {
         this.parent.render.call(this);
         var parsed = editableNgOptionsParser(this.attrs.eNgOptions);
-        var html = '<label ng-repeat="'+parsed.ngRepeat+'">'+
-          '<input type="radio" ng-disabled="' + this.attrs.eNgDisabled + '" ng-model="$parent.$parent.$data" value="{{'+parsed.locals.valueFn+'}}">'+
-          '<span ng-bind="'+parsed.locals.displayFn+'"></span></label>';
+
+        var html = '<label data-ng-repeat="'+parsed.ngRepeat+'">'+
+          '<input type="radio" data-ng-disabled="::' + this.attrs.eNgDisabled + '" data-ng-model="$parent.$parent.$data" value="{{::'+parsed.locals.valueFn+'}}">'+
+          '<span data-ng-bind="::'+parsed.locals.displayFn+'"></span></label>';
 
         this.inputEl.removeAttr('ng-model');
         this.inputEl.removeAttr('ng-options');

--- a/src/js/directives/uiselect.js
+++ b/src/js/directives/uiselect.js
@@ -34,7 +34,7 @@ angular.module('xeditable').directive('editableUiSelect',['editableDirectiveFact
                 this.inputEl.append(rename('ui-select-match', match[index].element));
                 this.inputEl.append(rename('ui-select-choices', choices[index].element));
                 this.inputEl.removeAttr('ng-model');
-                this.inputEl.attr('ng-model', '$parent.$data');
+                this.inputEl.attr('ng-model', '$parent.$parent.$data');
             }
         });
 

--- a/src/js/editable-element/controller.js
+++ b/src/js/editable-element/controller.js
@@ -245,7 +245,7 @@ angular.module('xeditable').factory('editableController',
       }
 
       self.inputEl.addClass('editable-input');
-      self.inputEl.attr('ng-model', '$data');
+      self.inputEl.attr('ng-model', '$parent.$data');
 
       // add directiveName class to editor, e.g. `editable-text`
       self.editorEl.addClass(editableUtils.camelToDash(self.directiveName));
@@ -272,6 +272,8 @@ angular.module('xeditable').factory('editableController',
         valueGetter($scope.$parent);
     };
 
+    // reference of the scope to use for $compile
+    var newScope = null;
     //show
     self.show = function() {
       // set value of scope.$data
@@ -288,7 +290,8 @@ angular.module('xeditable').factory('editableController',
       $element.after(self.editorEl);
 
       // compile (needed to attach ng-* events from markup)
-      $compile(self.editorEl)($scope);
+      newScope = $scope.$new();
+      $compile(self.editorEl)(newScope);
 
       // attach listeners (`escape`, autosubmit, etc)
       self.addListeners();
@@ -302,6 +305,9 @@ angular.module('xeditable').factory('editableController',
 
     //hide
     self.hide = function() {
+
+      // destroy the scope to prevent memory leak
+      newScope.$destroy();
 
       self.controlsEl.remove();
       self.editorEl.remove();

--- a/test/e2e/dev-test.html
+++ b/test/e2e/dev-test.html
@@ -33,6 +33,7 @@
     <script src="../../docs/demos/editable-column/test.js"></script>
     <script src="../../docs/demos/editable-table/test.js"></script>
     <script src="../../docs/demos/uiselect/test.js"></script>
+    <script src="../../docs/demos/editable-popover/test.js"></script>
 
     <!-- dev only tests -->
     <script src="../../docs/demos/dev-text/test.js"></script>

--- a/test/e2e/docs-test.html
+++ b/test/e2e/docs-test.html
@@ -34,6 +34,7 @@
     <script src="../../docs/demos/editable-column/test.js"></script>
     <script src="../../docs/demos/editable-table/test.js"></script>
     <script src="../../docs/demos/uiselect/test.js"></script>
+    <script src="../../docs/demos/editable-popover/test.js"></script>
   </head>
   <body>
   </body>


### PR DESCRIPTION
- Add popover functionality.  Taken from http://ryanlanciaux.github.io/blog/2013/10/16/fake-popovers-for-angular-xeditable/
- Updated ui-select test
- Updated editable-form documentation to include note about e-required
- Removed e-required from editable-row example
- Updated radiolist demo to use one-way binding to reduce number of watchers
- This could close #210, #146, #81