### PR TITLE
datepicker-append-to-body directive now matches uib-datepicker

### DIFF
--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -26,7 +26,7 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
                 inputDatePicker.attr('clear-text', this.attrs.eClearText || 'Clear');
                 inputDatePicker.attr('close-text', this.attrs.eCloseText || 'Done');
                 inputDatePicker.attr('close-on-date-selection', this.attrs.eCloseOnDateSelection || true);
-                inputDatePicker.attr('datepicker-append-to-body', this.attrs.eDatePickerAppendToBody || false);
+                inputDatePicker.attr('datepicker-append-to-body', this.attrs.eDatepickerAppendToBody || this.attrs.eDatePickerAppendToBody || false);
                 inputDatePicker.attr('date-disabled', this.attrs.eDateDisabled);
                 inputDatePicker.attr('name', this.attrs.eName);
                 inputDatePicker.attr('on-open-focus', this.attrs.eOnOpenFocus || true);


### PR DESCRIPTION
`uib-datepicker-popup` directive for append to body is `datepicker-append-to-body`. It is expected when putting `e-datepicker-append-to-body` in an `editable-bsdate` that it would work. However, we have to enter `e-date-picker-append-to-body` and there is no mention of this in your documentation. This makes your `editable-bsdate` match `uib-datepicker-popup` documentation while still being retro-compatible.