### PR TITLE
Use datepicker's default settings

### DIFF
--- a/docs/demos/bsdate/view.html
+++ b/docs/demos/bsdate/view.html
@@ -1,5 +1,8 @@
 <div ng-controller="BsdateCtrl">
-  <a href="#" editable-bsdate="user.dob" e-is-open="opened.$data" e-ng-click="open($event,'$data')" e-datepicker-popup="dd-MMMM-yyyy">
+  <a href="#" editable-bsdate="user.dob"
+              e-is-open="opened.$data"
+              e-ng-click="open($event,'$data')"
+              e-datepicker-popup="dd-MMMM-yyyy">
     {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}
   </a>
 </div>

--- a/docs/demos/dev-bsdate/view.html
+++ b/docs/demos/dev-bsdate/view.html
@@ -1,54 +1,54 @@
 <div ng-controller="DevBsdateCtrl">
-  <a href="#" data-editable-bsdate="user.dob"
-              data-e-is-open="opened.$data"
-              data-e-ng-click="open($event,'$data')"
-              data-e-datepicker-popup="dd-MMMM-yyyy"
-              data-e-min-date="getMinDate()"
-              data-e-max-date="getMaxDate()"
-              data-e-on-open-focus="true"
-              data-e-style="color: white; background-color: green"
+  <a href="#" editable-bsdate="user.dob"
+              e-is-open="opened.$data"
+              e-ng-click="open($event,'$data')"
+              e-datepicker-popup="dd-MMMM-yyyy"
+              e-min-date="getMinDate()"
+              e-max-date="getMaxDate()"
+              e-on-open-focus="true"
+              e-style="color: white; background-color: green"
               id="minMax"
               class="minMax">
     {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}
   </a>
   &nbsp;
-  <a href="#" data-editable-bsdate="user.startDate"
-              data-e-is-open="opened.$data"
-              data-e-ng-click="open($event,'$data')"
-              data-e-datepicker-popup="dd-MMMM-yyyy"
-              data-e-init-date="getInitDate()"
+  <a href="#" editable-bsdate="user.startDate"
+              e-is-open="opened.$data"
+              e-ng-click="open($event,'$data')"
+              e-datepicker-popup="dd-MMMM-yyyy"
+              e-init-date="getInitDate()"
               id="initDate"
               class="initDate">
     {{ (user.startDate | date:"dd/MM/yyyy") || 'empty' }}
   </a>
   &nbsp;
-  <a href="#" data-editable-bsdate="user.hireDate"
-              data-e-is-open="opened.$data"
-              data-e-ng-click="open($event,'$data')"
-              data-e-datepicker-popup="dd-MMMM-yyyy"
-              data-e-init-date="getInitDate()"
-              data-e-on-open-focus="true"
-              data-e-readonly="true"
+  <a href="#" editable-bsdate="user.hireDate"
+              e-is-open="opened.$data"
+              e-ng-click="open($event,'$data')"
+              e-datepicker-popup="dd-MMMM-yyyy"
+              e-init-date="getInitDate()"
+              e-on-open-focus="true"
+              e-readonly="true"
               id="readOnly"
               class="readOnly">
     {{ (user.hireDate | date:"dd/MM/yyyy") || 'empty' }}
   </a>
   &nbsp;
-  <a href="#" data-editable-bsdate="user.dob"
-              data-e-is-open="opened.$data"
-              data-e-ng-click="open($event,'$data')"
-              data-e-datepicker-popup="dd-MMMM-yyyy"
-              data-e-ng-change="changed($parent.$data)"
+  <a href="#" editable-bsdate="user.dob"
+              e-is-open="opened.$data"
+              e-ng-click="open($event,'$data')"
+              e-datepicker-popup="dd-MMMM-yyyy"
+              e-ng-change="changed($parent.$data)"
               id="onChangeDate"
               class="onChangeDate">
     {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}
   </a>
   &nbsp;
-  <a href="#" data-editable-bsdate="user.dob"
-             data-e-is-open="opened.$data"
-             data-e-ng-click="open($event,'$data')"
-             data-e-datepicker-popup="dd-MMMM-yyyy"
-             data-e-show-calendar-button="false"
+  <a href="#" editable-bsdate="user.dob"
+             e-is-open="opened.$data"
+             e-ng-click="open($event,'$data')"
+             e-datepicker-popup="dd-MMMM-yyyy"
+             e-show-calendar-button="false"
              id="hideCalendarButton"
              class="hideCalendarButton">
     {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}

--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -2,8 +2,40 @@
  Angular-ui bootstrap datepicker
  http://angular-ui.github.io/bootstrap/#/datepicker
  */
-angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFactory',
-    function(editableDirectiveFactory) {
+angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFactory', '$injector', '$parse',
+    function(editableDirectiveFactory, $injector, $parse) {
+
+        // Constants from Angular-ui bootstrap datepicker
+        uibDatepickerConfig = $injector.get('uibDatepickerConfig');
+        uibDatepickerPopupConfig = $injector.get('uibDatepickerPopupConfig');
+
+        var popupAttrNames = [
+            ['eIsOpen', 'is-open'],
+            ['eDateDisabled', 'date-disabled'],
+            ['eDatepickerPopup', 'uib-datepicker-popup'],
+            ['eShowButtonBar', 'show-button-bar'],
+            ['eCurrentText', 'current-text'],
+            ['eClearText', 'clear-text'],
+            ['eCloseText', 'close-text'],
+            ['eCloseOnDateSelection', 'close-on-date-selection'],
+            ['eDatePickerAppendToBody', 'datepicker-append-to-body'],
+            ['eOnOpenFocus', 'on-open-focus'],
+            ['eName', 'name'],
+            ['eDateDisabled', 'date-disabled']
+        ];
+
+        var dateOptionsNames = [
+            ['eFormatDay', 'formatDay'],
+            ['eFormatMonth', 'formatMonth'],
+            ['eFormatYear', 'formatYear'],
+            ['eFormatDayHeader', 'formatDayHeader'],
+            ['eFormatDayTitle', 'formatDayTitle'],
+            ['eFormatMonthTitle', 'formatMonthTitle'],
+            ['eMaxMode', 'maxMode'],
+            ['eMinMode', 'minMode'],
+            ['eDatepickerMode', 'datepickerMode']
+        ];
+
         return editableDirectiveFactory({
             directiveName: 'editableBsdate',
             inputTpl: '<div></div>',
@@ -14,66 +46,69 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
                  **/
                 this.parent.render.call(this);
 
-                var inputDatePicker = angular.element('<input type="text" class="form-control" data-ng-model="$parent.$data"/>');
+                var attrs = this.attrs;
+                var scope = this.scope;
 
-                inputDatePicker.attr('uib-datepicker-popup', this.attrs.eDatepickerPopupXEditable || 'yyyy/MM/dd' );
-                inputDatePicker.attr('is-open', this.attrs.eIsOpen);
-                inputDatePicker.attr('date-disabled', this.attrs.eDateDisabled);
-                inputDatePicker.attr('uib-datepicker-popup', this.attrs.eDatepickerPopup);
-                inputDatePicker.attr('year-range', this.attrs.eYearRange || 20);
-                inputDatePicker.attr('show-button-bar', this.attrs.eShowButtonBar || true);
-                inputDatePicker.attr('current-text', this.attrs.eCurrentText || 'Today');
-                inputDatePicker.attr('clear-text', this.attrs.eClearText || 'Clear');
-                inputDatePicker.attr('close-text', this.attrs.eCloseText || 'Done');
-                inputDatePicker.attr('close-on-date-selection', this.attrs.eCloseOnDateSelection || true);
-                inputDatePicker.attr('datepicker-append-to-body', this.attrs.eDatePickerAppendToBody || false);
-                inputDatePicker.attr('date-disabled', this.attrs.eDateDisabled);
-                inputDatePicker.attr('name', this.attrs.eName);
-                inputDatePicker.attr('on-open-focus', this.attrs.eOnOpenFocus || true);
-                inputDatePicker.attr('ng-readonly', this.attrs.eReadonly || false);
+                var inputDatePicker = angular.element('<input type="text" class="form-control" ng-model="$parent.$data"/>');
 
-                if (this.attrs.eNgChange) {
-                    inputDatePicker.attr('ng-change', this.attrs.eNgChange);
+                inputDatePicker.attr('uib-datepicker-popup', attrs.eDatepickerPopupXEditable || uibDatepickerPopupConfig.datepickerPopup );
+                inputDatePicker.attr('year-range', attrs.eYearRange || 20);
+                inputDatePicker.attr('ng-readonly', attrs.eReadonly || false);
+
+                for (var i = popupAttrNames.length - 1; i >= 0; i--) {
+                    var popupAttr = attrs[popupAttrNames[i][0]];
+                    if (typeof popupAttr !== 'undefined') {
+                        inputDatePicker.attr(popupAttrNames[i][1], popupAttr);
+                    }
+                }
+
+                if (attrs.eNgChange) {
+                    inputDatePicker.attr('ng-change', attrs.eNgChange);
                     this.inputEl.removeAttr('ng-change');
                 }
 
-                if (this.attrs.eStyle) {
-                    inputDatePicker.attr('style', this.attrs.eStyle);
+                if (attrs.eStyle) {
+                    inputDatePicker.attr('style', attrs.eStyle);
                     this.inputEl.removeAttr('style');
                 }
 
-                this.scope.dateOptions = {
-                    formatDay:  this.attrs.eFormatDay || 'dd',
-                    formatMonth: this.attrs.eFormatMonth || 'MMMM',
-                    formatYear: this.attrs.eFormatYear || 'yyyy',
-                    formatDayHeader: this.attrs.eFormatDayHeader || 'EEE',
-                    formatDayTitle: this.attrs.eFormatDayTitle || 'MMMM yyyy',
-                    formatMonthTitle: this.attrs.eFormatMonthTitle || 'yyyy',
-                    showWeeks: this.attrs.eShowWeeks ? this.attrs.eShowWeeks.toLowerCase() === 'true' : true,
-                    startingDay: this.attrs.eStartingDay || 0,
-                    minMode: this.attrs.eMinMode || 'day',
-                    maxMode: this.attrs.eMaxMode || 'year',
-                    initDate: this.scope.$eval(this.attrs.eInitDate) || new Date(),
-                    datepickerMode: this.attrs.eDatepickerMode || 'day',
-                    maxDate: this.scope.$eval(this.attrs.eMaxDate) || null,
-                    minDate: this.scope.$eval(this.attrs.eMinDate) || null
+                var dateOptions = {
+                    maxDate: scope.$eval(attrs.eMaxDate) || uibDatepickerConfig.maxDate,
+                    minDate: scope.$eval(attrs.eMinDate) || uibDatepickerConfig.minDate,
+                    showWeeks: attrs.eShowWeeks ? attrs.eShowWeeks.toLowerCase() === 'true' : uibDatepickerConfig.showWeeks,
+                    startingDay: attrs.eStartingDay || 0,
+                    initDate: scope.$eval(attrs.eInitDate) || new Date()
                 };
 
-                var showCalendarButton = angular.isDefined(this.attrs.eShowCalendarButton) ? this.attrs.eShowCalendarButton : "true";
+                if (attrs.eDatepickerOptions) {
+                    var eDatepickerOptions = $parse(attrs.eDatepickerOptions)(scope);
+                    angular.extend(dateOptions, eDatepickerOptions);
+                }
+
+                for (var z = dateOptionsNames.length - 1; z >= 0; z--) {
+                    var doAttr = attrs[dateOptionsNames[z][0]];
+                    if (typeof doAttr !== 'undefined') {
+                        dateOptions[dateOptionsNames[z][1]] = doAttr;
+                    }
+                }
+
+                scope.dateOptions = dateOptions;
+
+                var showCalendarButton = angular.isDefined(attrs.eShowCalendarButton) ? attrs.eShowCalendarButton : "true";
 
                 //See if calendar button should be displayed
                 if (showCalendarButton === "true") {
                     var buttonDatePicker = angular.element('<button type="button" class="btn btn-default"><i class="glyphicon glyphicon-calendar"></i></button>');
                     var buttonWrapper = angular.element('<span class="input-group-btn"></span>');
 
-                    buttonDatePicker.attr('ng-click', this.attrs.eNgClick);
+                    buttonDatePicker.attr('ng-click', attrs.eNgClick);
 
                     buttonWrapper.append(buttonDatePicker);
 
                     this.inputEl.append(buttonWrapper);
                 } else {
                     //If no calendar button, display calendar popup on click of input field
-                    inputDatePicker.attr('ng-click', this.attrs.eNgClick);
+                    inputDatePicker.attr('ng-click', attrs.eNgClick);
                 }
 
                 inputDatePicker.attr('datepicker-options', "dateOptions");
@@ -91,5 +126,5 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
                 this.inputEl.removeAttr('name');
                 this.inputEl.attr('class','input-group');
             }
-	});
+    });
 }]);


### PR DESCRIPTION
The datepicker and the popup have default settings in their constants uibDatepickerConfig and uibDatepickerPopupConfig. They can be set for all datepickers in the whole angular app.

Using uibDatepickerConfig and uibDatepickerPopupConfig makes the datepicker generated by xeditable consistent with the standard datepickers in an app without doing anything - no need to set every single setting for the xeditable datepicker.

Also the generated attributes, that don't have value different from the default, don't need to be set so they won't.