### PR TITLE
Added support to jQuery UI Datepicker for AngularJS

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,8 @@
     "checklist-model": "^0.10.0",
     "ng-tags-input": "^3.1.1",
     "angular-bootstrap": "^1.3.3",
-    "angular-ui-select": "^0.16.1"
+    "angular-ui-select": "^0.16.1",
+    "jquery-ui": "^1.12.1",
+    "angular-ui-date": "^1.0.1"
   }
 }

--- a/docs/demos/uidate/controller.js
+++ b/docs/demos/uidate/controller.js
@@ -1,0 +1,12 @@
+app.controller('UidateCtrl', function($scope) {
+
+    $scope.datePickerConfig = {
+        changeYear: true,
+        changeMonth: true
+    };
+
+    $scope.user = {
+        dob: new Date(1985, 3, 11)
+    };
+
+});

--- a/docs/demos/uidate/desc.md
+++ b/docs/demos/uidate/desc.md
@@ -1,0 +1,41 @@
+Date control is implemented via [jQuery UI Datepicker for AngularJS](https://github.com/angular-ui/ui-date).  
+
+You should install ui-date with bower:
+
+        bower install angular-ui-date --save	
+
+Add the CSS:
+
+```html
+<link rel="stylesheet" href="bower_components/jquery-ui/themes/smoothness/jquery-ui.css"/>
+```
+
+Load the script files (minimun jQuery version is v2.2.0):
+
+```html
+<script type="text/javascript" src="bower_components/jquery/jquery.js"></script>
+<script type="text/javascript" src="bower_components/jquery-ui/jquery-ui.js"></script>
+<script type="text/javascript" src="bower_components/angular/angular.js"></script>
+<script type="text/javascript" src="bower_components/angular-ui-date/dist/date.js"></script>
+```
+
+Add the date module as a dependency to your application module:
+
+```js
+angular.module('MyApp', ['ui.date'])
+```
+
+And set `editable-uidate` attribute in editable element.  
+
+You can pass an `e-ui-date` attribute pointing to an object with a picker configuration that you may want.
+
+```js
+var datePickerOptions = {
+    changeYear: true,
+    changeMonth: true,
+    showOn: "button",
+    buttonImage: "build/assets/img/calendar.png",
+    buttonImageOnly: true
+};
+```
+

--- a/docs/demos/uidate/test.js
+++ b/docs/demos/uidate/test.js
@@ -1,0 +1,15 @@
+describe('uidate', function() {
+
+  beforeEach(function() {
+    browser().navigateTo(mainUrl);
+  });
+
+  it('should show editor and submit new value', function() {
+    var s = '[ng-controller="UidateCtrl"] ';
+
+    expect(element(s+'a[editable-uidate]').css('display')).not().toBe('none');
+    expect(element(s+'a[editable-uidate]').text()).toMatch('11/03/1985');
+    element(s+'a[editable-uidate]').click();
+
+  });
+});

--- a/docs/demos/uidate/view.html
+++ b/docs/demos/uidate/view.html
@@ -1,0 +1,6 @@
+<div ng-controller="UidateCtrl">
+    <span editable-uidate="user.dob"
+        e-ui-date="datePickerConfig">
+        {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}
+    </span>
+</div>

--- a/docs/jade/scripts-dev.jade
+++ b/docs/jade/scripts-dev.jade
@@ -10,6 +10,9 @@ link(href="bower_components/angular-ui-select/dist/select.css", rel="stylesheet"
 link(href="bower_components/ng-tags-input/ng-tags-input.css", rel="stylesheet", media="screen")
 link(href="bower_components/ng-tags-input/ng-tags-input.bootstrap.css", rel="stylesheet", media="screen")
 
+//jquery-ui css
+link(href="bower_components/jquery-ui/themes/smoothness/jquery-ui.css", rel="stylesheet", media="screen")
+
 //xeditable css
 link(href="src/css/xeditable.css", rel="stylesheet", media="screen")
 
@@ -18,6 +21,9 @@ link(href="docs/css/docs.css", rel="stylesheet", media="screen")
 
 //jquery (needed for bootstrap)? for dev include before angular!
 script(src="bower_components/jquery/dist/jquery.js")
+
+//jquery ui
+script(src="bower_components/jquery-ui/jquery-ui.js")
 
 //angular
 script(src='bower_components/angular/angular.js')
@@ -28,6 +34,9 @@ script(src="bower_components/bootstrap/dist/js/bootstrap.js")
 
 //angular-ui-bootstrap
 script(src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js")
+
+//angular-ui-date
+script(src="bower_components/angular-ui-date/dist/date.js")
 
 //ui-select
 script(src="bower_components/angular-ui-select/dist/select.js")
@@ -70,5 +79,6 @@ script(src='src/js/directives/checklist.js')
 script(src='src/js/directives/uiselect.js')
 script(src='src/js/directives/ngtags.js')
 script(src='src/js/directives/combodate.js')
+script(src='src/js/directives/uidate.js')
 
 

--- a/docs/js/structure.js
+++ b/docs/js/structure.js
@@ -11,6 +11,7 @@ module.exports = [
         {id: 'checklist', text: 'Checklist', fiddle: ''},
         {id: 'radiolist', text: 'Radiolist', fiddle: ''},
         {id: 'bsdate', text: 'Date', fiddle: 'http://jsfiddle.net/ckosloski/NfPcH/17531/', fiddleText: 'View Bootstrap 3 jsFiddle'},
+        {id: 'uidate', text: 'UI Date', fiddle: ''},
         {id: 'bstime', text: 'Time', fiddle: 'http://jsfiddle.net/NfPcH/34/', fiddleText: 'View Bootstrap 2 jsFiddle'},
         {id: 'combodate', text: 'DateTime', fiddle: '', fiddleText: 'No jsFiddle'},
         {id: 'typeahead', text: 'Typeahead', fiddle: 'http://jsfiddle.net/NfPcH/46/', fiddleText: 'View Bootstrap 2 jsFiddle'},

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ For themes you may need to include [Twitter Bootstrap](http://getbootstrap.com) 
 For some extra controls (e.g. datepicker) you may need to include [angular-ui bootstrap](http://angular-ui.github.io/bootstrap/).
 To use ui-select you will need to include [angular-ui ui-select](https://github.com/angular-ui/ui-select/).
 To use ngTagsInput you will need to include [mbenford ngTagsInput](https://github.com/mbenford/ngTagsInput).
+To use ui-date you will need to include [angular-ui ui-date](https://github.com/angular-ui/ui-date).
 
 ## Reporting issues and Contributing
 Please read our [Contributor guidelines](CONTRIBUTING.md) before reporting an issue or creating a pull request.

--- a/src/js/directives/uidate.js
+++ b/src/js/directives/uidate.js
@@ -1,0 +1,16 @@
+/*
+ jQuery UI Datepicker for AngularJS
+ https://github.com/angular-ui/ui-date
+ */
+angular.module('xeditable').directive('editableUidate', ['editableDirectiveFactory',
+    function(editableDirectiveFactory) {
+        return editableDirectiveFactory({
+            directiveName: 'editableUidate',
+            inputTpl: '<input class="form-control" />',
+            render: function() {
+                this.parent.render.call(this);
+                this.inputEl.attr('ui-date', this.attrs.eUiDate);
+                this.inputEl.attr('placeholder', this.attrs.ePlaceholder);
+            }
+        });
+}]);


### PR DESCRIPTION
Implementation of editableUiDate directive to be able to use [jQuery UI datepicker for AngularJS](https://github.com/angular-ui/ui-date) 

To use the new directive you simple do this:

`<span editable-uidate="yourModel" e-ui-date="datePickerConfig">{{ yourModel }}</span> `

And use it as you normally will use the jQuery UI datepicker.