### PR TITLE
Add support for alt-input-formats to bsdate.

### DIFF
--- a/docs/demos/dev-bsdate/controller.js
+++ b/docs/demos/dev-bsdate/controller.js
@@ -16,7 +16,9 @@ app.controller('DevBsdateCtrl', function($scope) {
 	$scope.getInitDate = function($event, elementOpened) {
 		return new Date();
 	};
-	
+
+	$scope.altInputFormats = ['d/M/yy'];
+
 	$scope.opened = {};
 
 	$scope.open = function($event, elementOpened) {

--- a/docs/demos/dev-bsdate/test.js
+++ b/docs/demos/dev-bsdate/test.js
@@ -178,4 +178,22 @@ describe('dev-bsdate', function() {
     expect(element(s+'a#hideCalendarButton').text()).toMatch('29/04/1984');
     expect(element(s+'form').count()).toBe(0);
   });
+
+
+  it('should allow alternate input formats for date', function() {
+    var s = '[ng-controller="DevBsdateCtrl"] ';
+
+    expect(element(s+'a#altInputFormats').css('display')).not().toBe('none');
+    expect(element(s+'a#altInputFormats').text()).toMatch('15/05/1984');
+
+    element(s+'a#altInputFormats').click();
+
+    // enter alternate input date format and submit
+    input('$parent.$data').enter('3/1/17');
+    element(s+'form button[type="submit"]').click();
+
+    expect(element(s+'a#altInputFormats').css('display')).not().toBe('none');
+    expect(element(s+'a#altInputFormats').text()).toMatch('03/01/2017');
+    expect(element(s+'form').count()).toBe(0);
+  });
 });

--- a/docs/demos/dev-bsdate/view.html
+++ b/docs/demos/dev-bsdate/view.html
@@ -53,4 +53,15 @@
              class="hideCalendarButton">
     {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}
   </a>
+
+  <a href="#" editable-bsdate="user.dob"
+     e-is-open="opened.$data"
+     e-ng-click="open($event,'$data')"
+     e-datepicker-popup="dd-MMMM-yyyy"
+     e-ng-change="changed($parent.$data)"
+     e-alt-input-formats="altInputFormats"
+     id="altInputFormats"
+     class="altInputFormats">
+    {{ (user.dob | date:"dd/MM/yyyy") || 'empty' }}
+  </a>
 </div>

--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -21,7 +21,8 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
             ['eDatePickerAppendToBody', 'datepicker-append-to-body'],
             ['eOnOpenFocus', 'on-open-focus'],
             ['eName', 'name'],
-            ['eDateDisabled', 'date-disabled']
+            ['eDateDisabled', 'date-disabled'],
+            ['eAltInputFormats', 'alt-input-formats']
         ];
 
         var dateOptionsNames = [


### PR DESCRIPTION
Add support for the angular datepicker-popup component's `alt-input-formats` attribute that was not previously supported by angular-xeditable's bsdate component.