### PR TITLE
Correction of the reading of the datepicker-append-to-body attribute.

### DIFF
--- a/src/js/directives/bsdate.js
+++ b/src/js/directives/bsdate.js
@@ -18,7 +18,7 @@ angular.module('xeditable').directive('editableBsdate', ['editableDirectiveFacto
             ['eClearText', 'clear-text'],
             ['eCloseText', 'close-text'],
             ['eCloseOnDateSelection', 'close-on-date-selection'],
-            ['eDatePickerAppendToBody', 'datepicker-append-to-body'],
+            ['eDatepickerAppendToBody', 'datepicker-append-to-body'],
             ['eOnOpenFocus', 'on-open-focus'],
             ['eName', 'name'],
             ['eDateDisabled', 'date-disabled'],


### PR DESCRIPTION
Hi, here is a pull request that corrects the reading of the datepicker-append-to-body attribute. Without this using e-datepicker-append-to-body is not recognized. There was a previous similar pull request in Nov 2016 but it hasn't been integrated because of conflicts. Hopefully this one works.

Thank you.