### PR TITLE
Change main entry to index.js and export module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/js/xeditable.js');
+module.exports = 'xeditable';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Vitaliy Potapov",
     "email": "noginsk@rambler.ru"
   },
-  "main": "dist/js/xeditable.js",
+  "main": "index.js",
   "style": "dist/css/xeditable.css",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,17 @@ npm install angular-xeditable
 ````
 #### Manual
 Download latest version from [project homepage](https://vitalets.github.io/angular-xeditable).
+
 #### Insert dependency 
 ````
 var app = angular.module("app", ["xeditable"]);
 ````
+#### Usage with a Asset/Module Bundler
+```js
+import angularXeditable from 'angular-xeditable';
+
+angular.module('app', [angularXeditable]);
+```
 
 ## Dependencies
 Basically it does not depend on any libraries except [AngularJS](http://angularjs.org) itself.    


### PR DESCRIPTION
With this PR it is possible to to do:

```JS
import angularXeditable from 'angular-xeditable';

angular.module('app', [angularXeditable]);
```

and have on less verbose string to worry about in Angular 1 ;)
